### PR TITLE
Change git:// to https:// in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/Rapptz/discord.py@master
+git+https://github.com/Rapptz/discord.py@master
 dnspython==2.1.0
 gspread==3.7.0
 requests==2.25.1


### PR DESCRIPTION
The unencrypted git:// protocol is no longer supported by GitHub, so trying to grab the discord.py requirement will fail and thus prevent VeraBot from being properly installed.

This PR changes the protocol to https:// instead, which is encrypted and officially supported by GitHub.