### PR TITLE
Implement Slash Commands

### DIFF
--- a/app.py
+++ b/app.py
@@ -368,46 +368,13 @@ def dm_or_test_only():
     return commands.check(predicate)
 
 @bot.command(
-    help="Can be called with just $verify but also with $verify <VTuber name>\n" +
-    "Both versions require a screenshot sent with it.",
-	brief=" Tries to verify a screenshot for membership in the DMs"
+    help="Obsolete verify command, notifies user to use slash command version instead.",
+	brief="Obsolete verify command."
 )
 @dm_or_test_only()
 @commands.cooldown(verify_tries, 50, commands.BucketType.user)
 async def verify(ctx, *args):
-    """
-    Command in the DMs that tries to verify a screenshot for membership.
-    """
-    # log content to dm log channel for record
-    dm_lg_ch = bot.get_channel(dm_log)
-    await dm_lg_ch.send("{} ({})\n{}".format(str(ctx.author), str(ctx.author.id), ctx.message.content))
-    # check for needed picture
-    if not ctx.message.attachments:
-        NO_PICTURE_TEXT = "I'm sorry {}, you need to provide a valid photo along with the ``verify`` command to complete the verification process.\n The image should be a **direct upload** and not a shareable link (Ex. Imgure, lighshot etc)"
-        await ctx.message.channel.send(NO_PICTURE_TEXT.format(ctx.author))
-        logging.info("Verify without screenshot from %s.", ctx.author.id)
-        return
-
-    if args:
-        server = Utility.map_vtuber_to_server(args[0])
-
-        if len(args) > 1:
-            language = Utility.map_language(args[1])
-        else:
-            language = "eng"
-
-        if server:
-            if Utility.is_user_on_server(ctx.author.id, server):
-                # only give vtuber name if it is a multi-server
-                await member_handler.add_to_queue(ctx.message, server, language, args[0] if Utility.is_multi_server(server) else None)
-            else:
-                logging.info("%s tried to verify for a server they are not on.", ctx.author.id)
-                await ctx.send("You are not on {} server!".format(args[0].title()))
-        else:
-            embed = Utility.create_supported_vtuber_embed()
-            await ctx.send(content ="Please use a valid supported VTuber!", embed = embed)
-    else:
-        await member_handler.add_to_queue(ctx.message)
+    await ctx.send("This command no longer works through DMs, please use the slash command '/verify' in the server instead.")
 
 @verify.error
 async def verify_error(ctx, error):

--- a/app.py
+++ b/app.py
@@ -501,7 +501,7 @@ async def proof_error(ctx, error):
 @commands.is_owner()
 @commands.guild_only()
 async def syncGuild(ctx):
-    ctx.tree.copy_global_to(guild=ctx.guild)
+    ctx.bot.tree.copy_global_to(guild=ctx.guild)
     await ctx.bot.tree.sync(guild=ctx.guild)
     await ctx.send("commands synced to guild")
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 #External
 from database import Database
 import discord
+from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands.errors import CommandNotFound
 from pymongo import MongoClient
@@ -494,6 +495,21 @@ async def proof_error(ctx, error):
     embed = Utility.create_supported_vtuber_embed()
     await ctx.send(content=None, embed=embed)
 
+# slash commands must be synced manually, guild for the current guild (good for testing), and global for all servers
+
+@bot.command(name="syncGuild")
+@commands.is_owner()
+@commands.guild_only()
+async def syncGuild(ctx):
+    await ctx.bot.tree.sync(guild=ctx.guild)
+    await ctx.send("commands synced to guild")
+
+@bot.command(name="syncGlobal")
+@commands.is_owner()
+@commands.guild_only()
+async def syncGlobal(ctx):
+    await ctx.bot.tree.sync()
+    await ctx.send("commands synced globally")
 
 #Time in status
 async def jst_clock():

--- a/app.py
+++ b/app.py
@@ -501,6 +501,7 @@ async def proof_error(ctx, error):
 @commands.is_owner()
 @commands.guild_only()
 async def syncGuild(ctx):
+    ctx.tree.copy_global_to(guild=ctx.guild)
     await ctx.bot.tree.sync(guild=ctx.guild)
     await ctx.send("commands synced to guild")
 

--- a/app.py
+++ b/app.py
@@ -472,6 +472,14 @@ async def syncGuild(ctx):
     await ctx.bot.tree.sync(guild=ctx.guild)
     await ctx.send("commands synced to guild")
 
+@bot.command(name="syncGuildClear")
+@commands.is_owner()
+@commands.guild_only()
+async def syncGuildClear(ctx):
+    # since all commands are global, doing a sync call without the copy_global_to function will clear all guild synced commands
+    await ctx.bot.tree.sync(guild=ctx.guild)
+    await ctx.send("guild commands cleared from sync")
+
 @bot.command(name="syncGlobal")
 @commands.is_owner()
 @commands.guild_only()

--- a/database.py
+++ b/database.py
@@ -179,7 +179,7 @@ class ServerDatabase:
             })
         else:
             logging.info("Updating membership for %s on server %s with last membership: %s.", member_id, self.server_id, db_date)
-            self.__get_member_collection().update_one({"id": member_id}, {"$set": {"last_membership": db_date, "informed": False, "expiry_sent": False}})
+            self.__get_member_collection().update_one({"id": member_id}, {"$set": { "informed": False, "expiry_sent": False}, "$max": {"last_membership": db_date}})
 
     @overload
     def remove_member(self, member: int) -> int:
@@ -252,7 +252,7 @@ class ServerDatabase:
             })
         else:
             logging.info("Updating membership for %s to talent %s on server %s with last membership: %s.", member_id, vtuber, self.server_id, db_date)
-            self.__get_member_collection().update_one({"id": member_id, "idol": vtuber}, {"$set": {"last_membership": db_date, "informed": False, "expiry_sent": False}})
+            self.__get_member_collection().update_one({"id": member_id, "idol": vtuber}, {"$set": { "informed": False, "expiry_sent": False}, "$max": {"last_membership": db_date}})
 
     @overload
     def remove_member_multi(self, member: int, vtuber) -> int:

--- a/membership.py
+++ b/membership.py
@@ -63,6 +63,13 @@ class Membership(commands.Cog):
             await self.member_handler.view_membership(interaction, None, None)
 
 
+    @view_members_multi.autocomplete('vtuber')
+    async def view_members_multi_autocomplete(self, interaction: discord.Interaction, current: str):
+        server_db = Database().get_server_db(interaction.guild_id)
+        multi_talents = server_db.get_multi_talents()
+        vtubers = [m['idol'] for m in multi_talents]
+        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
+
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
@@ -70,6 +77,14 @@ class Membership(commands.Cog):
     async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: str, vtuber: str=None):
         logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
         await self.member_handler.set_membership(interaction, member.id, date, manual = True, vtuber = vtuber)
+    
+        
+    @set_membership.autocomplete('vtuber')
+    async def set_membership_autocomplete(self, interaction: discord.Interaction, current: str):
+        server_db = Database().get_server_db(interaction.guild_id)
+        multi_talents = server_db.get_multi_talents()
+        vtubers = [m['idol'] for m in multi_talents]
+        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
 
 
     @app_commands.command(name="delmember",
@@ -77,7 +92,14 @@ class Membership(commands.Cog):
     @app_commands.checks.has_permissions(manage_messages=True)
     async def del_membership(self, interaction: discord.Interaction, member: discord.User, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
-        await self.member_handler.del_membership(interaction.message, member.id, text, manual = True, vtuber = vtuber)
+        await self.member_handler.del_membership(interaction, member.id, text, manual = True, vtuber = vtuber)
+
+    @del_membership.autocomplete('vtuber')
+    async def del_membership_autocomplete(self, interaction: discord.Interaction, current: str):
+        server_db = Database().get_server_db(interaction.guild_id)
+        multi_talents = server_db.get_multi_talents()
+        vtubers = [m['idol'] for m in multi_talents]
+        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
 
 
     @app_commands.command(name="purgemember",

--- a/membership.py
+++ b/membership.py
@@ -54,7 +54,7 @@ class Membership(commands.Cog):
         if Utility.is_multi_server(interaction.guild_id):
             multi_talents = server_db.get_multi_talents()
             vtubers = [m['idol'] for m in multi_talents]
-            return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
+            return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if current.lower() in vtuber.lower()]
         else:
             vtuber = server_db.get_vtuber()
             return [app_commands.Choice(name=vtuber, value=vtuber)]
@@ -88,7 +88,7 @@ class Membership(commands.Cog):
         server_db = Database().get_server_db(interaction.guild_id)
         multi_talents = server_db.get_multi_talents()
         vtubers = [m['idol'] for m in multi_talents]
-        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
+        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if current.lower() in vtuber.lower()]
 
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
@@ -105,7 +105,7 @@ class Membership(commands.Cog):
         server_db = Database().get_server_db(interaction.guild_id)
         multi_talents = server_db.get_multi_talents()
         vtubers = [m['idol'] for m in multi_talents]
-        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
+        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if current.lower() in vtuber.lower()]
 
 
     @app_commands.command(name="delmember",
@@ -121,7 +121,7 @@ class Membership(commands.Cog):
         server_db = Database().get_server_db(interaction.guild_id)
         multi_talents = server_db.get_multi_talents()
         vtubers = [m['idol'] for m in multi_talents]
-        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
+        return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if current.lower() in vtuber.lower()]
 
 
     @app_commands.command(name="purgemember",

--- a/membership.py
+++ b/membership.py
@@ -95,18 +95,6 @@ class Membership(commands.Cog):
         await self.member_handler.purge_memberships(interaction.guild_id)
         await interaction.response.send_message("This was a hard check, it might have hit many members that still have a valid membership.", ephemeral=True)
 
-    @del_membership.error
-    @view_members.error
-    async def id_error(self, interaction: discord.Interaction, error):
-        if isinstance(error, commands.BadArgument):
-            logging.debug("%s used invalid ID for delMember or viewMember.", interaction.user.id)
-            await interaction.response.send_message("Please provide a valid id!", ephemeral=True)
-        elif isinstance(error, commands.MissingRequiredArgument):
-            logging.debug("%s forgot argument for delMember or viewMember.", interaction.user.id)
-            await interaction.response.send_message("Please include the argument!", ephemeral=True)
-
-# hidden commands are not possible with slash commands (todo: figure out what to do with these)
-
     @commands.command(hidden = True, name = "queue")
     @commands.is_owner()
     async def queue(self, ctx):

--- a/membership.py
+++ b/membership.py
@@ -49,7 +49,7 @@ class Membership(commands.Cog):
             await self.member_handler.add_to_queue(interaction, attachment)
     
     @verify.autocomplete('vtuber')
-    async def view_members_multi_autocomplete(self, interaction: discord.Interaction, current: str):
+    async def verify_autocomplete(self, interaction: discord.Interaction, current: str):
         server_db = Database().get_server_db(interaction.guild_id)
         if Utility.is_multi_server(interaction.guild_id):
             multi_talents = server_db.get_multi_talents()

--- a/membership.py
+++ b/membership.py
@@ -17,21 +17,18 @@ class Membership(commands.Cog):
     def __init__(self, bot, member_handler: MembershipHandler):
         self.bot = bot
         self.member_handler = member_handler
-        
+
+    # postional varaiables are not supported in slash commands, so these commands will only view all members for now (todo: make these commands a group)    
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def view_members(self, interaction: discord.Interaction, *member_id: int):
-        if member_id:
-            logging.info(f"{interaction.user.id} used viewMember with ID in {interaction.guild_id}")
-            await self.member_handler.view_membership(interaction.message, member_id[0], None)
-        else:
-            logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
-            await self.member_handler.view_membership(interaction.message, None)
+    async def view_members(self, interaction: discord.Interaction):
+        logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
+        await self.member_handler.view_membership(interaction.message, None)
 
     @app_commands.command(name="viewmembersfor",
         description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber. Or if a id is given additionally this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def view_members_multi(self, interaction: discord.Interaction, vtuber=None, *member_id: int):
+    async def view_members_multi(self, interaction: discord.Interaction, vtuber :str=None):
         if vtuber:
             logging.info("%s viewed all members in %s for %s", interaction.user.id, interaction.guild_id, vtuber)
             await self.member_handler.view_membership(interaction.message, None, vtuber)
@@ -45,7 +42,7 @@ class Membership(commands.Cog):
         "<date> has to be in the format dd/mm/yyyy. " +
         "It equals the date shown on the sent screenshot")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def set_membership(self, interaction: discord.Interaction, member_id: int, date, vtuber=None):
+    async def set_membership(self, interaction: discord.Interaction, member_id: int, date: int, vtuber: str=None):
         logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
         await self.member_handler.set_membership(interaction.message, member_id, date, manual = True, vtuber = vtuber)
 
@@ -63,7 +60,7 @@ class Membership(commands.Cog):
         description="Removes the membership role from the user whose ID was given. " +
         "A text which is sent to the user as DM can be given but is optional.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def del_membership(self, interaction: discord.Interaction, member_id: int, vtuber=None, *text):
+    async def del_membership(self, interaction: discord.Interaction, member_id: int, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
         await self.member_handler.del_membership(interaction.message, member_id, text, manual = True, vtuber = vtuber)
 

--- a/membership.py
+++ b/membership.py
@@ -49,7 +49,7 @@ class Membership(commands.Cog):
             await self.member_handler.add_to_queue(interaction, attachment)
 
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
-    @app_commands.checks.default_permissions(manage_messages=True)
+    @app_commands.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def view_members(self, interaction: discord.Interaction, member: discord.User=None):
         if member:
@@ -61,7 +61,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="viewmembersfor",
         description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber.")
-    @app_commands.checks.default_permissions(manage_messages=True)
+    @app_commands.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def view_members_multi(self, interaction: discord.Interaction, vtuber :str=None):
         if vtuber:
@@ -81,7 +81,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
-    @app_commands.checks.default_permissions(manage_messages=True)
+    @app_commands.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     @app_commands.describe(date='Date has to be in the format dd/mm/yyyy.')
     async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: str, vtuber: str=None):
@@ -99,7 +99,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="delmember",
         description="Removes the membership role from the user whose ID was given.")
-    @app_commands.checks.default_permissions(manage_messages=True)
+    @app_commands.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def del_membership(self, interaction: discord.Interaction, member: discord.User, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
@@ -115,7 +115,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="purgemember",
     description="Initiates a Membership Check")
-    @app_commands.checks.default_permissions(manage_messages=True)
+    @app_commands.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def purge_members(self, interaction: discord.Interaction):
         await self.member_handler.purge_memberships(interaction.guild_id)

--- a/membership.py
+++ b/membership.py
@@ -17,30 +17,31 @@ class Membership(commands.Cog):
     def __init__(self, bot, member_handler: MembershipHandler):
         self.bot = bot
         self.member_handler = member_handler
-
-    # postional varaiables are not supported in slash commands, so these commands will only view all members for now (todo: make these commands a group)    
+   
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def view_members(self, interaction: discord.Interaction):
-        logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
-        await self.member_handler.view_membership(interaction.message, None)
+    async def view_members(self, interaction: discord.Interaction, member_id: str=None):
+        if member_id:
+            logging.info(f"{interaction.user.id} used viewMember with ID in {interaction.guild_id}")
+            await self.member_handler.view_membership(interaction, int(member_id), None)
+        else:
+            logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
+            await self.member_handler.view_membership(interaction, None)
 
     @app_commands.command(name="viewmembersfor",
-        description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber. Or if a id is given additionally this users data.")
+        description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber.")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def view_members_multi(self, interaction: discord.Interaction, vtuber :str=None):
         if vtuber:
             logging.info("%s viewed all members in %s for %s", interaction.user.id, interaction.guild_id, vtuber)
-            await self.member_handler.view_membership(interaction.message, None, vtuber)
+            await self.member_handler.view_membership(interaction, None, vtuber)
         else:
             logging.info("%s viewed all members in %s", interaction.user.id, interaction.guild_id)
-            await self.member_handler.view_membership(interaction.message, None, None)
+            await self.member_handler.view_membership(interaction, None, None)
 
 
     @app_commands.command(name="addmember",
-        description="Gives the membership role to the user whose ID was given. " + 
-        "<date> has to be in the format dd/mm/yyyy. " +
-        "It equals the date shown on the sent screenshot")
+        description="Gives the membership role to the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def set_membership(self, interaction: discord.Interaction, member_id: int, date: int, vtuber: str=None):
         logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
@@ -57,8 +58,7 @@ class Membership(commands.Cog):
 
 
     @app_commands.command(name="delmember",
-        description="Removes the membership role from the user whose ID was given. " +
-        "A text which is sent to the user as DM can be given but is optional.")
+        description="Removes the membership role from the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def del_membership(self, interaction: discord.Interaction, member_id: int, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
@@ -66,8 +66,7 @@ class Membership(commands.Cog):
 
 
     @app_commands.command(name="purgemember",
-    description="This will initiate a membership check which also removes members that MIGHT already have lost their membership. " +
-    "CAUTION: This will also hit many members that are still valid (Timezones and exact time of membering ...)")
+    description="Initiates a Membership Check")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def purge_members(self, interaction: discord.Interaction):
         await self.member_handler.purge_memberships(interaction.guild_id)

--- a/membership.py
+++ b/membership.py
@@ -43,7 +43,7 @@ class Membership(commands.Cog):
             await self.member_handler.add_to_queue(interaction, attachment)
 
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
-    @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.checks.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def view_members(self, interaction: discord.Interaction, member: discord.User=None):
         if member:
@@ -55,7 +55,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="viewmembersfor",
         description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber.")
-    @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.checks.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def view_members_multi(self, interaction: discord.Interaction, vtuber :str=None):
         if vtuber:
@@ -75,7 +75,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
-    @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.checks.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     @app_commands.describe(date='Date has to be in the format dd/mm/yyyy.')
     async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: str, vtuber: str=None):
@@ -93,7 +93,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="delmember",
         description="Removes the membership role from the user whose ID was given.")
-    @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.checks.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def del_membership(self, interaction: discord.Interaction, member: discord.User, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
@@ -109,7 +109,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="purgemember",
     description="Initiates a Membership Check")
-    @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.checks.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def purge_members(self, interaction: discord.Interaction):
         await self.member_handler.purge_memberships(interaction.guild_id)

--- a/membership.py
+++ b/membership.py
@@ -20,6 +20,7 @@ class Membership(commands.Cog):
         self.member_handler = member_handler
 
     @app_commands.command(name="verify", description="Tries to verify a screenshot for membership in the DMs")
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def verify(self, interaction: discord.Interaction, attachment: discord.Attachment, vtuber: str=None, language: str=None):
         if not attachment.content_type.startswith("image"):
             await interaction.response.send_message("The included attachment is not an image, please attach an image.", ephemeral=True)
@@ -43,6 +44,7 @@ class Membership(commands.Cog):
 
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def view_members(self, interaction: discord.Interaction, member: discord.User=None):
         if member:
             logging.info(f"{interaction.user.id} used viewMember with ID in {interaction.guild_id}")
@@ -54,6 +56,7 @@ class Membership(commands.Cog):
     @app_commands.command(name="viewmembersfor",
         description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber.")
     @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def view_members_multi(self, interaction: discord.Interaction, vtuber :str=None):
         if vtuber:
             logging.info("%s viewed all members in %s for %s", interaction.user.id, interaction.guild_id, vtuber)
@@ -73,6 +76,7 @@ class Membership(commands.Cog):
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     @app_commands.describe(date='Date has to be in the format dd/mm/yyyy.')
     async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: str, vtuber: str=None):
         logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
@@ -90,6 +94,7 @@ class Membership(commands.Cog):
     @app_commands.command(name="delmember",
         description="Removes the membership role from the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def del_membership(self, interaction: discord.Interaction, member: discord.User, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
         await self.member_handler.del_membership(interaction, member.id, text, manual = True, vtuber = vtuber)
@@ -105,6 +110,7 @@ class Membership(commands.Cog):
     @app_commands.command(name="purgemember",
     description="Initiates a Membership Check")
     @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def purge_members(self, interaction: discord.Interaction):
         await self.member_handler.purge_memberships(interaction.guild_id)
         await interaction.response.send_message("This was a hard check, it might have hit many members that still have a valid membership.", ephemeral=True)

--- a/membership.py
+++ b/membership.py
@@ -43,10 +43,10 @@ class Membership(commands.Cog):
                 embed = Utility.create_supported_vtuber_embed()
                 await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed, ephemeral=True)
         elif Utility.is_multi_server(interaction.guild_id):
-                embed = Utility.create_supported_vtuber_embed()
-                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed, ephemeral=True)
+            embed = Utility.create_supported_vtuber_embed()
+            await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed, ephemeral=True)
         else:
-            await self.member_handler.add_to_queue(interaction, attachment)
+            await self.member_handler.add_to_queue(interaction, attachment, interaction.guild_id)
     
     @verify.autocomplete('vtuber')
     async def verify_autocomplete(self, interaction: discord.Interaction, current: str):

--- a/membership.py
+++ b/membership.py
@@ -28,6 +28,9 @@ class Membership(commands.Cog):
         if vtuber or language:
             if vtuber:
                 server = Utility.map_vtuber_to_server(vtuber)
+            elif Utility.is_multi_server(interaction.guild_id):
+                embed = Utility.create_supported_vtuber_embed()
+                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
 
             if language:
                 language = Utility.map_language(language)
@@ -37,6 +40,9 @@ class Membership(commands.Cog):
             if server:
                 await self.member_handler.add_to_queue(interaction, attachment, server, language, vtuber)
             else:
+                embed = Utility.create_supported_vtuber_embed()
+                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
+        elif Utility.is_multi_server(interaction.guild_id):
                 embed = Utility.create_supported_vtuber_embed()
                 await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
         else:

--- a/membership.py
+++ b/membership.py
@@ -47,6 +47,17 @@ class Membership(commands.Cog):
                 await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
         else:
             await self.member_handler.add_to_queue(interaction, attachment)
+    
+    @verify.autocomplete('vtuber')
+    async def view_members_multi_autocomplete(self, interaction: discord.Interaction, current: str):
+        server_db = Database().get_server_db(interaction.guild_id)
+        if Utility.is_multi_server(interaction.guild_id):
+            multi_talents = server_db.get_multi_talents()
+            vtubers = [m['idol'] for m in multi_talents]
+            return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers]
+        else:
+            vtuber = server_db.get_vtuber()
+            return [app_commands.Choice(name=vtuber, value=vtuber)]
 
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
     @app_commands.default_permissions(manage_messages=True)

--- a/membership.py
+++ b/membership.py
@@ -18,7 +18,7 @@ class Membership(commands.Cog):
         self.bot = bot
         self.member_handler = member_handler
         
-    @app_commands.command(name="viewMembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
+    @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def view_members(self, interaction: discord.Interaction, *member_id: int):
         if member_id:
@@ -28,7 +28,7 @@ class Membership(commands.Cog):
             logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
             await self.member_handler.view_membership(interaction.message, None)
 
-    @app_commands.command(name="viewMembersFor",
+    @app_commands.command(name="viewmembersfor",
         description = "Shows all user with the membership role. Or if a vtuber is given for that VTuber. Or if a id is given additionally this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def view_members_multi(self, interaction: discord.Interaction, vtuber=None, *member_id: int):
@@ -40,7 +40,7 @@ class Membership(commands.Cog):
             await self.member_handler.view_membership(interaction.message, None, None)
 
 
-    @app_commands.command(name="addMember",
+    @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given. " + 
         "<date> has to be in the format dd/mm/yyyy. " +
         "It equals the date shown on the sent screenshot")
@@ -59,7 +59,7 @@ class Membership(commands.Cog):
             await interaction.response.send_message("One of the arguments has the wrong data type!", ephemeral=True)
 
 
-    @app_commands.command(name="delMember",
+    @app_commands.command(name="delmember",
         description="Removes the membership role from the user whose ID was given. " +
         "A text which is sent to the user as DM can be given but is optional.")
     @app_commands.checks.has_permissions(manage_messages=True)
@@ -68,7 +68,7 @@ class Membership(commands.Cog):
         await self.member_handler.del_membership(interaction.message, member_id, text, manual = True, vtuber = vtuber)
 
 
-    @app_commands.command(name="purgeMember",
+    @app_commands.command(name="purgemember",
     description="This will initiate a membership check which also removes members that MIGHT already have lost their membership. " +
     "CAUTION: This will also hit many members that are still valid (Timezones and exact time of membering ...)")
     @app_commands.checks.has_permissions(manage_messages=True)

--- a/membership.py
+++ b/membership.py
@@ -30,7 +30,7 @@ class Membership(commands.Cog):
                 server = Utility.map_vtuber_to_server(vtuber)
             elif Utility.is_multi_server(interaction.guild_id):
                 embed = Utility.create_supported_vtuber_embed()
-                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
+                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed, ephemeral=True)
 
             if language:
                 language = Utility.map_language(language)
@@ -41,10 +41,10 @@ class Membership(commands.Cog):
                 await self.member_handler.add_to_queue(interaction, attachment, server, language, vtuber)
             else:
                 embed = Utility.create_supported_vtuber_embed()
-                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
+                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed, ephemeral=True)
         elif Utility.is_multi_server(interaction.guild_id):
                 embed = Utility.create_supported_vtuber_embed()
-                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed)
+                await interaction.response.send_message(content ="Please use a valid supported VTuber!", embed = embed, ephemeral=True)
         else:
             await self.member_handler.add_to_queue(interaction, attachment)
     

--- a/membership.py
+++ b/membership.py
@@ -66,18 +66,10 @@ class Membership(commands.Cog):
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: int, vtuber: str=None):
+    @app_commands.describe(date='Date has to be in the format dd/mm/yyyy.')
+    async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: str, vtuber: str=None):
         logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
-        await self.member_handler.set_membership(interaction.message, member.id, date, manual = True, vtuber = vtuber)
-
-    @set_membership.error
-    async def set_membership_error(self, interaction: discord.Interaction, error):
-        if isinstance(error, commands.MissingRequiredArgument):
-            logging.debug("%s forgot argument for addMember", interaction.user.id)
-            await interaction.response.send_message("Please include at least two arguments!", ephemeral=True)
-        elif isinstance(error, commands.BadArgument):
-            logging.debug("%s used an invalid argument for addMember.", interaction.user.id)
-            await interaction.response.send_message("One of the arguments has the wrong data type!", ephemeral=True)
+        await self.member_handler.set_membership(interaction, member.id, date, manual = True, vtuber = vtuber)
 
 
     @app_commands.command(name="delmember",

--- a/membership.py
+++ b/membership.py
@@ -20,10 +20,10 @@ class Membership(commands.Cog):
    
     @app_commands.command(name="viewmembers", description = "Shows all user with the membership role. Or if a id is given this users data.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def view_members(self, interaction: discord.Interaction, member_id: str=None):
-        if member_id:
+    async def view_members(self, interaction: discord.Interaction, member: discord.User=None):
+        if member:
             logging.info(f"{interaction.user.id} used viewMember with ID in {interaction.guild_id}")
-            await self.member_handler.view_membership(interaction, int(member_id), None)
+            await self.member_handler.view_membership(interaction, member.id, None)
         else:
             logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
             await self.member_handler.view_membership(interaction, None)
@@ -43,9 +43,9 @@ class Membership(commands.Cog):
     @app_commands.command(name="addmember",
         description="Gives the membership role to the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def set_membership(self, interaction: discord.Interaction, member_id: int, date: int, vtuber: str=None):
+    async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: int, vtuber: str=None):
         logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
-        await self.member_handler.set_membership(interaction.message, member_id, date, manual = True, vtuber = vtuber)
+        await self.member_handler.set_membership(interaction.message, member.id, date, manual = True, vtuber = vtuber)
 
     @set_membership.error
     async def set_membership_error(self, interaction: discord.Interaction, error):
@@ -60,9 +60,9 @@ class Membership(commands.Cog):
     @app_commands.command(name="delmember",
         description="Removes the membership role from the user whose ID was given.")
     @app_commands.checks.has_permissions(manage_messages=True)
-    async def del_membership(self, interaction: discord.Interaction, member_id: int, vtuber: str=None, text: str=None):
+    async def del_membership(self, interaction: discord.Interaction, member: discord.User, vtuber: str=None, text: str=None):
         logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
-        await self.member_handler.del_membership(interaction.message, member_id, text, manual = True, vtuber = vtuber)
+        await self.member_handler.del_membership(interaction.message, member.id, text, manual = True, vtuber = vtuber)
 
 
     @app_commands.command(name="purgemember",

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -148,7 +148,6 @@ class MembershipHandler:
             count = 0
             embed_count = 0
             m = ""
-            embeds = []
             for member in server_db.get_members():
                 if Utility.is_multi_server(interaction.guild_id) and vtuber is not None and member.idol != vtuber:
                     continue
@@ -157,22 +156,23 @@ class MembershipHandler:
                 membership_date = member.last_membership + relativedelta(months=1)
                 membership_date = membership_date.strftime(self.DATE_FORMAT)
                 new_line = "{}: {}\n".format(member_id, membership_date)
-                if len(m) + len(new_line) > 2048:
+                if len(m) + len(new_line) > 4096:
                     if embed_count == 0:
                         embed = discord.Embed(title = "Membership List", description = m)
+                        await interaction.followup.send(content = None, embed = embed, ephemeral=True)
                     else:
                         embed = discord.Embed(description = m)
-                    embeds.append(embed)
+                        await interaction.followup.send(content = None, embed = embed, ephemeral=True)
                     embed_count += 1
                     m = ""
                 m += new_line
             if m != "":
                 if embed_count == 0:
                     embed = discord.Embed(title = "Membership List", description = m + "Member count: " + str(count))
+                    await interaction.followup.send(content = None, embed = embed, ephemeral=True)
                 else:
                     embed = discord.Embed(description = m + "Member count: " + str(count))
-                embeds.append(embed)
-                await interaction.followup.send(content = None, embeds = embeds, ephemeral=True)
+                    await interaction.followup.send(content = None, embed = embed, ephemeral=True)
             else:
                 await interaction.followup.send("No active memberships!", ephemeral=True)
             return

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -93,7 +93,7 @@ class MembershipHandler:
                     target_member = guild.get_member(member.id)
 
                     if target_member:
-                        if Utility.is_multi_server(guild):
+                        if Utility.is_multi_server(guild.id):
                             role_id = server_db.get_multi_talent_role_from_name(idol)
                         else:
                             role_id = server_db.get_member_role()

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -515,7 +515,10 @@ class MembershipHandler:
                     if text:
                         await target_member.send(text)
                     else:
-                        await target_member.send("Your membership for " + server_db.get_vtuber() + " was deleted!")
+                        if vtuber:
+                            await target_member.send("Your membership for " + vtuber + " was deleted!")
+                        else:
+                            await target_member.send("Your membership for " + server_db.get_vtuber() + " was deleted!")
             except (discord.errors.Forbidden, discord.HTTPException):
                 if isinstance(res, discord.Interaction):
                     await res.response.send_message("Removing the role failed, please remove the role manually and check my permissions.", ephemeral=True)

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -290,6 +290,8 @@ class MembershipHandler:
             #verification channel of the server
             if vtuber:
                 member_veri_ch = self.bot.get_channel(server_db.get_multi_talent_log_channel(vtuber))
+                if not member_veri_ch:
+                    member_veri_ch = member_veri_ch = self.bot.get_channel(server_db.get_log_channel())
             else:
                 member_veri_ch = self.bot.get_channel(server_db.get_log_channel())
             

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -143,7 +143,7 @@ class MembershipHandler:
     async def view_membership(self, interaction, member_id=None, vtuber=None):
         # if msg is empty, show all members
         server_db = self.db.get_server_db(interaction.guild_id)
-
+        await interaction.response.defer(ephemeral=True, thinking=True)
         if not member_id:
             count = 0
             embed_count = 0
@@ -172,9 +172,9 @@ class MembershipHandler:
                 else:
                     embed = discord.Embed(description = m + "Member count: " + str(count))
                 embeds.append(embed)
-                await interaction.response.send_message(content = None, embeds = embeds, ephemeral=True)
+                await interaction.followup.send(content = None, embeds = embeds, ephemeral=True)
             else:
-                await interaction.response.send_message("No active memberships!", ephemeral=True)
+                await interaction.followup.send("No active memberships!", ephemeral=True)
             return
 
         # Check if zoopass in database and delete
@@ -183,7 +183,7 @@ class MembershipHandler:
         else:
             target_membership = server_db.get_member(member_id)
         if not target_membership:
-            await interaction.response.send_message(self.ID_NOT_FOUND_TEXT, ephemeral=True)
+            await interaction.followup.send(self.ID_NOT_FOUND_TEXT, ephemeral=True)
             return
         
         # Send information about membership
@@ -201,7 +201,7 @@ class MembershipHandler:
         m = m.format(str(target_member), member_id, membership_date, expiration_date)
         embed = discord.Embed(title = "Membership", description = m)
 
-        await interaction.response.send_message(content=None, embed = embed, ephemeral=True)
+        await interaction.followup.send(content=None, embed = embed, ephemeral=True)
         
     """
     {

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -164,7 +164,7 @@ class MembershipHandler:
                         embed = discord.Embed(description = m)
                     embeds.append(embed)
                     embed_count += 1
-                    m +=  ""
+                    m = ""
                 m += new_line
             if m != "":
                 if embed_count == 0:

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -157,7 +157,7 @@ class MembershipHandler:
                 membership_date = member.last_membership + relativedelta(months=1)
                 membership_date = membership_date.strftime(self.DATE_FORMAT)
                 new_line = "{}: {}\n".format(member_id, membership_date)
-                if len(m) + len(new_line) > 4000:
+                if len(m) + len(new_line) > 2048:
                     if embed_count == 0:
                         embed = discord.Embed(title = "Membership List", description = m)
                     else:

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -432,8 +432,11 @@ class MembershipHandler:
 
         if len(dates)!=3 or any(not Utility.is_integer(date) for date in dates):
             logging.info("%s used a wrong date format to set the membership.", author_id)
-
-            await res.response.send_message("Please provide a valid date (dd/mm/yyyy).", ephemeral=True)
+            # Differentiate between reaction and manual add
+            if actor:
+                await res.reply("{} Please use 'no/wrong date recognized' instead".format(actor.mention))
+            else:
+                await res.response.send_message("Please provide a valid date (dd/mm/yyyy).", ephemeral=True)
             return False
         try:
             new_date = dtime(year = int(dates[2]), month = int(dates[1]), day = int(dates[0]), tzinfo = timezone.utc)

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -157,7 +157,7 @@ class MembershipHandler:
                 membership_date = member.last_membership + relativedelta(months=1)
                 membership_date = membership_date.strftime(self.DATE_FORMAT)
                 new_line = "{}: {}\n".format(member_id, membership_date)
-                if len(m) + len(new_line) > 4096:
+                if len(m) + len(new_line) > 4000:
                     if embed_count == 0:
                         embed = discord.Embed(title = "Membership List", description = m)
                     else:

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -63,7 +63,7 @@ class MembershipHandler:
         notify_date = expiry_date + timedelta(days=inform_duration)
 
         message_title = idol.title() + " Membership {}!"
-        end_text = "You may renew your membership by sending another updated verification photo using the ``$verify`` command.\n"
+        end_text = "You may renew your membership by sending another updated verification photo using the ``/verify`` command.\n"
         end_text += "Thank you so much for your continued support!"
         if purge:
             end_text = "This expiration may be too soon. It was initiated by the server to avoid illegit access during e.g. a membership stream.\n"

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -408,38 +408,39 @@ class MembershipHandler:
 
 
     async def set_membership(self, res, member_id, date, manual=True, actor=None, vtuber=None) -> bool:
+        if isinstance(res, discord.Interaction):
+            guild_id = res.guild_id
+            author_id = res.user.id
+        elif isinstance(res, discord.Message):
+            guild_id = res.guild.id
+            author_id = res.author.id
         dates = date.split("/")
 
         if len(dates)!=3 or any(not Utility.is_integer(date) for date in dates):
-            logging.info("%s used a wrong date format to set the membership.", res.author.id)
+            logging.info("%s used a wrong date format to set the membership.", author_id)
 
-            await res.channel.send("Please provide a valid date (dd/mm/yyyy).")
+            await res.response.send_message("Please provide a valid date (dd/mm/yyyy).", ephemeral=True)
             return False
         try:
             new_date = dtime(year = int(dates[2]), month = int(dates[1]), day = int(dates[0]), tzinfo = timezone.utc)
         except ValueError:
-            logging.info("%s used a invalid number for the date to set the membership.", res.author.id)
-            await res.channel.send("Your date was not valid. Please use the format dd/mm/yyyy")
+            logging.info("%s used a invalid number for the date to set the membership.", author_id)
+            await res.response.send_message("Your date was not valid. Please use the format dd/mm/yyyy", ephemeral=True)
             return False
 
         target_member = res.guild.get_member(member_id)
 
-        # stop if user not on server
-        if not target_member:
-            await res.channel.send("{} is not on this server!".format(target_member.mention), reference=res, mention_author=False)
-            return True
-
         db_date = new_date - relativedelta(months=1)
-        server_db = self.db.get_server_db(res.guild.id)
+        server_db = self.db.get_server_db(guild_id)
 
         # update/create member in db
-        if Utility.is_multi_server(res.guild.id):
+        if Utility.is_multi_server(guild_id):
             server_db.update_member_multi(member_id, db_date, vtuber)
         else:
             server_db.update_member(member_id, db_date)
 
         # if multi-server get role depending on name
-        if Utility.is_multi_server(res.guild.id):
+        if Utility.is_multi_server(guild_id):
             role_id = server_db.get_multi_talent_role_from_name(vtuber)
         else:
             role_id = server_db.get_member_role()
@@ -447,7 +448,7 @@ class MembershipHandler:
             
         role = res.guild.get_role(role_id)
         await target_member.add_roles(role)
-        logging.info("Added member role to user %s on server %s.", member_id, res.guild.id)
+        logging.info("Added member role to user %s on server %s.", member_id, guild_id)
 
         await asyncio.sleep(0.21)
 
@@ -455,7 +456,7 @@ class MembershipHandler:
 
         await asyncio.sleep(0.21)
         if manual:
-            await res.channel.send("New membership date for {} set at {}!".format(target_member.mention, new_date.strftime(self.DATE_FORMAT)), reference=res, mention_author=False)
+            await res.response.send_message("New membership date for {} set at {}!".format(target_member.mention, new_date.strftime(self.DATE_FORMAT)), ephemeral=True)
         else:
             embed = res.embeds[0]
             embed.description = "**VERIFIED:** {}\nUser: {}\nBy: {}".format(new_date.strftime(self.DATE_FORMAT), target_member.mention, actor.mention)
@@ -464,28 +465,38 @@ class MembershipHandler:
         
 
     async def del_membership(self, res, member_id: int, text, dm_flag=True, manual=True, vtuber=None):
-        server_db = self.db.get_server_db(res.guild.id)
+        if isinstance(res, discord.Interaction):
+            guild_id = res.guild_id
+            author_id = res.user.id
+        elif isinstance(res, discord.Message):
+            guild_id = res.guild.id
+            author_id = res.author.id
+        
+        server_db = self.db.get_server_db(guild_id)
         result = 0
 
         # Delete from db
-        if Utility.is_multi_server(res.guild.id) and vtuber:
+        if Utility.is_multi_server(guild_id) and vtuber:
             result = server_db.remove_member_multi(member_id, vtuber)
         else:
             result = server_db.remove_member(member_id)
         if result == 0:
-            logging.info("Requested user does not have membership; by %s.", res.author.id)
-            await res.channel.send(self.ID_NOT_FOUND_TEXT)
+            logging.info("Requested user does not have membership; by %s.", author_id)
+            if isinstance(res, discord.Interaction):
+                await res.response.send_message(self.ID_NOT_FOUND_TEXT, ephemeral=True)
+            elif isinstance(res, discord.Message):
+                await res.channel.send(self.ID_NOT_FOUND_TEXT)
             return
-        if Utility.is_multi_server(res.guild.id):
-            logging.info("Deleted membership on %s: %s for %s", res.guild.id, member_id, vtuber)
+        if Utility.is_multi_server(guild_id):
+            logging.info("Deleted membership on %s: %s for %s", guild_id, member_id, vtuber)
         else:
-            logging.info("Deleted membership on %s: %s", res.guild.id, member_id)
+            logging.info("Deleted membership on %s: %s", guild_id, member_id)
 
         # Remove member role from user
         guild = res.guild
         target_member = guild.get_member(member_id)
 
-        if Utility.is_multi_server(res.guild.id):
+        if Utility.is_multi_server(guild_id):
             role_id = server_db.get_multi_talent_role_from_name(vtuber)
         else:
             role_id = server_db.get_member_role()
@@ -494,22 +505,28 @@ class MembershipHandler:
         if target_member:
             try: 
                 await target_member.remove_roles(role)
-                logging.info("Removing role %s from %s on server %s.", role.name, member_id, res.guild.id)
+                logging.info("Removing role %s from %s on server %s.", role.name, member_id, guild_id)
 
                 if manual:
-                    await res.channel.send("Membership successfully deleted.")
+                    await res.response.send_message("Membership successfully deleted.", ephemeral=True)
 
                 if dm_flag:
                     # If msg has extra lines, send dm to target user to notify the zoopass deletion
                     if text:
-                        await target_member.send(" ".join(text))
+                        await target_member.send(text)
                     else:
                         await target_member.send("Your membership for " + server_db.get_vtuber() + " was deleted!")
             except (discord.errors.Forbidden, discord.HTTPException):
-                await res.channel.send("Removing the role failed, please remove the role manually and check my permissions.")
+                if isinstance(res, discord.Interaction):
+                    await res.response.send_message("Removing the role failed, please remove the role manually and check my permissions.", ephemeral=True)
+                elif isinstance(res, discord.Message):
+                    await res.channel.send("Removing the role failed, please remove the role manually and check my permissions.")
         else:
-            await res.channel.send("User is not on this server!")
-            logging.info("%s not on server %s.", member_id, res.guild.id)
+            if isinstance(res, discord.Interaction):
+                await res.response.send_message("User is not on this server!", ephemeral=True)
+            elif isinstance(res, discord.Message):
+                await res.channel.send("User is not on this server!")
+            logging.info("%s not on server %s.", member_id, guild_id)
 
     async def purge_memberships(self, server_id: int):
         if Utility.is_multi_server(server_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Rapptz/discord.py@master
+discord.py>=2.0.0
 dnspython==2.2.1
 gspread==5.3.2
 requests==2.27.1

--- a/settings.py
+++ b/settings.py
@@ -14,7 +14,7 @@ class Settings(commands.Cog):
         self.bot = bot
         self.db = Database()
 
-    @app_commands.command(name="viewSettings", description="Shows all settings of this server.")
+    @app_commands.command(name="viewsettings", description="Shows all settings of this server.")
     @app_commands.checks.has_permissions(manage_messages=True)
     async def show_settings(self, interaction: discord.Interaction):
         logging.debug("%s called viewSettings.", interaction.user.id)
@@ -76,7 +76,7 @@ class Settings(commands.Cog):
         m += "<https://github.com/nonJerry/VeraBot/blob/master/settings.md>"
         await interaction.response.send_message(content=m, embed = embed, ephemeral=True)
 
-    @app_commands.command(name="setVTuber",
+    @app_commands.command(name="setvtuber",
         description="Sets the name of the VTuber of this server.\nThe screenshot sent for the verification is scanned for this name. Therefore this name should be identical with the name in the membership tab.")
     @app_commands.check.has_permissions(administrator=True)
     async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
@@ -99,7 +99,7 @@ class Settings(commands.Cog):
         return False
 
 
-    @app_commands.command(name="memberRole",
+    @app_commands.command(name="memberrole",
         description="Sets the role that should be given to a member who has proven that he has valid access to membership content.\nRequires the ID not the role name or anything else!")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_member_role(self, interaction: discord.Interaction, role_id: int):
@@ -112,7 +112,7 @@ class Settings(commands.Cog):
         logging.info("%s set %s as member role.", interaction.guild_id, role_id)
 
 
-    @app_commands.command(name="logChannel", description="Sets the channel which is used to control the sent memberships.\nRequires the ID not the role name or anything else!")
+    @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.\nRequires the ID not the role name or anything else!")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_log_channel(self, interaction: discord.Interaction, channel_id: int):
         if self.check_channel_integrity(channel_id):
@@ -139,7 +139,7 @@ class Settings(commands.Cog):
             await interaction.response.send_message("Please send a legit link. Only jpg, jpeg and png are accepted.", ephemeral=True)
 
 
-    @app_commands.command(name="setAuto", description = "Sets whether the bot is allowed to automatically add the membership role. Only allows True or False as input.")
+    @app_commands.command(name="setauto", description = "Sets whether the bot is allowed to automatically add the membership role. Only allows True or False as input.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_automatic_role(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -153,7 +153,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Flag for automatic role handling set to " + str(flag), ephemeral=True)
 
 
-    @app_commands.command(name="setAdditionalProof", description = "Sets whether the bot will require additional proof from the user. Only allows True or False as input.")
+    @app_commands.command(name="setadditionalproof", description = "Sets whether the bot will require additional proof from the user. Only allows True or False as input.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_require_additional_proof(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -167,7 +167,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Flag for additional Proof set to " + str(flag), ephemeral=True)
 
 
-    @app_commands.command(name="setTolerance", description = "Sets the time that users will have access to the membership channel after their membership expired.")
+    @app_commands.command(name="settolerance", description = "Sets the time that users will have access to the membership channel after their membership expired.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_tolerance_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -180,7 +180,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Time that users will still have access to the channel after their membership expired set to {} days.".format(str(time)), ephemeral=True)
 
 
-    @app_commands.command(name="setPriorNoticeDuration", description = "Sets how many days before the expiry of their membership a user will be notified to renew their proof.")
+    @app_commands.command(name="setpriornoticeduration", description = "Sets how many days before the expiry of their membership a user will be notified to renew their proof.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -192,7 +192,7 @@ class Settings(commands.Cog):
 
         await interaction.response.send_message("Users will be notified " + str(time) + " days before their membership ends.", ephemeral=True)
 
-    @app_commands.command(name="enableLogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
+    @app_commands.command(name="enablelogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_logging(self, interaction: discord.Interaction, flag):
         flag = Utility.text_to_boolean(flag)
@@ -206,7 +206,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Flag for logging set to " + str(flag), ephemeral=True)
 
 
-    @app_commands.command(name="proofChannel", description="Sets the Channel to which the threads will be attached.")
+    @app_commands.command(name="proofchannel", description="Sets the Channel to which the threads will be attached.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_proof_channel(self, interaction: discord.Interaction, channel_id: int):
         
@@ -227,7 +227,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Proof Channel id set to " + str(channel_id), ephemeral=True)
 
 
-    @app_commands.command(name="enableThreads", 
+    @app_commands.command(name="enablethreads", 
     description="Will activate the use of threads. The bot will create a Thread for each submitted proof. The log channel will be used to protocol the verified/denied proofs, not as place to verify them anymore. " +
     "Requires a proof channel to be set and use_public_threads to be enabled for this channel.")
     @app_commands.checks.has_permissions(administrator=True)
@@ -272,7 +272,7 @@ class Settings(commands.Cog):
             return False
         return True
 
-    @app_commands.command(name="enableMultiServer", description="Will activate the possibility to support several talents on one server.")
+    @app_commands.command(name="enablemultiserver", description="Will activate the possibility to support several talents on one server.")
     @app_commands.checks.has_permissions(administrator=True)
     async def enable_multi_server(self, interaction: discord.Interaction):
         if Utility.is_multi_server(interaction.guild_id):
@@ -289,7 +289,7 @@ class Settings(commands.Cog):
 
         await interaction.response.send_message("Management of several talents was activated for this server!", ephemeral=True)
 
-    @app_commands.command(name="disableMultiServer", description="Will disable the possibility to support several talents on one server.")
+    @app_commands.command(name="disablemultiserver", description="Will disable the possibility to support several talents on one server.")
     @app_commands.checks.has_permissions(administrator=True)
     async def disable_multi_server(self, interaction: discord.Interaction):
         if not Utility.is_multi_server(interaction.guild_id):
@@ -305,7 +305,7 @@ class Settings(commands.Cog):
     
 
 
-    @app_commands.command(name="addTalent", description="Adds new Talent to be supported. Also needs the log channel and role id. Function only for Multi-Talent servers!")
+    @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Also needs the log channel and role id. Function only for Multi-Talent servers!")
     @app_commands.checks.has_permissions(administrator=True)
     async def add_idol(self, interaction: discord.Interaction, name: str, log_id: int, role_id: int):
         if not Utility.is_multi_server(interaction.guild_id):
@@ -335,7 +335,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Successfully added the new talent!", ephemeral=True)
 
 
-    @app_commands.command(name="removeTalent", description="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!")
+    @app_commands.command(name="removetalent", description="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!")
     @app_commands.checks.has_permissions(administrator=True)
     async def remove_idol(self, interaction: discord.Interaction, name: str):
         if not Utility.is_multi_server(interaction.guild_id):

--- a/settings.py
+++ b/settings.py
@@ -39,9 +39,9 @@ class Settings(commands.Cog):
             member_role = server_db.get_member_role()
             embed.add_field(name='Member Role ID', value=str(member_role), inline=True)
 
-            # Log Channel
-            log_channel = server_db.get_log_channel()
-            embed.add_field(name='Log Channel ID', value=str(log_channel), inline=True)
+        # Log Channel
+        log_channel = server_db.get_log_channel()
+        embed.add_field(name='Log Channel ID', value=str(log_channel), inline=True)
 
         # current picture (als image anhängen)
         picture_url = server_db.get_picture()

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,5 @@
 # External
+from xmlrpc.client import Boolean
 from database import Database
 import discord
 from discord import app_commands
@@ -194,7 +195,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="enablelogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
     @app_commands.checks.has_permissions(administrator=True)
-    async def set_logging(self, interaction: discord.Interaction, flag):
+    async def set_logging(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
             await interaction.response.send_message(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
@@ -231,7 +232,7 @@ class Settings(commands.Cog):
     description="Will activate the use of threads. The bot will create a Thread for each submitted proof. The log channel will be used to protocol the verified/denied proofs, not as place to verify them anymore. " +
     "Requires a proof channel to be set and use_public_threads to be enabled for this channel.")
     @app_commands.checks.has_permissions(administrator=True)
-    async def toggle_threads(self, interaction: discord.Interaction, flag):
+    async def toggle_threads(self, interaction: discord.Interaction, flag: str):
         # multi-server cannot use threads
         if Utility.is_multi_server(interaction.guild_id):
             await interaction.response.send_message("You cannot enable threads as mutli-server!", ephemeral=True)

--- a/settings.py
+++ b/settings.py
@@ -348,31 +348,6 @@ class Settings(commands.Cog):
         else:
             await interaction.response.send_message("Could not remove {}!".format(name), ephemeral=True)
 
-# todo: remove these command errors (should no longer be needed with slash commands auto-complete feature)
-
-    @set_idol.error
-    @set_log_channel.error
-    @set_member_role.error
-    @set_automatic_role.error
-    @set_require_additional_proof.error
-    @set_tolerance_duration.error
-    @set_inform_duration.error
-    @set_picture.error
-    @set_logging.error
-    @toggle_threads.error
-    @set_proof_channel.error
-    @enable_multi_server.error
-    @disable_multi_server.error
-    @add_idol.error
-    #@toggle_threads.error
-    async def general_error(self, interaction: discord.Interaction, error):
-        if isinstance(error, commands.BadArgument):
-            logging.debug("%s used invalid ID for %s", interaction.user.id, interaction.command)
-            await interaction.response.send_message("Please provide a valid id!")
-        elif isinstance(error, commands.MissingRequiredArgument):
-            logging.debug("%s forgot argument for %s", interaction.user.id, interaction.command)
-            await interaction.response.send_message("Please include the argument!")
-
     def check_role_integrity(self, interaction: discord.Interaction, role_id: int):
         if interaction.guild.get_role(role_id):
             return True

--- a/settings.py
+++ b/settings.py
@@ -13,6 +13,7 @@ class Settings(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.db = Database()
+        self.BOOLEAN_ONLY_TEXT = "The Flag should only be True or False!"
 
     @app_commands.command(name="viewsettings", description="Shows all settings of this server.")
     @app_commands.default_permissions(manage_messages=True)

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,4 @@
 # External
-from xmlrpc.client import Boolean
 from database import Database
 import discord
 from discord import app_commands
@@ -200,7 +199,11 @@ class Settings(commands.Cog):
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
-            await interaction.response.send_message("This value needs to be at least 0 days.")
+            await interaction.response.send_message("This value needs to be at least 0 days.", ephemeral=True)
+            return
+        
+        if(time > 2):
+            await interaction.response.send_message("This value cannot be more than 2 days.", ephemeral=True)
             return
 
         self.db.get_server_db(interaction.guild_id).set_inform_duration(time)

--- a/settings.py
+++ b/settings.py
@@ -29,7 +29,7 @@ class Settings(commands.Cog):
         if Utility.is_multi_server(interaction.guild_id):
             multi_talents = server_db.get_multi_talents()
             idols = [m['idol'] for m in multi_talents]
-            vtubers = ', '.join(idols)
+            vtubers = ', '.join(idols).title()
             embed.add_field(name="VTubers", value=vtubers)
         else:
             vtuber = server_db.get_vtuber()

--- a/settings.py
+++ b/settings.py
@@ -103,23 +103,23 @@ class Settings(commands.Cog):
     @app_commands.command(name="memberrole",
         description="Sets the role for membership content")
     @app_commands.checks.has_permissions(administrator=True)
-    async def set_member_role(self, interaction: discord.Interaction, role_id: int):
-        if self.check_role_integrity(interaction, role_id):
-            self.db.get_server_db(interaction.guild_id).set_member_role(role_id)
+    async def set_member_role(self, interaction: discord.Interaction, role: discord.Role):
+        if self.check_role_integrity(interaction, role.id):
+            self.db.get_server_db(interaction.guild_id).set_member_role(role.id)
 
-            await interaction.response.send_message("Member role id set to " + str(role_id), ephemeral=True)
+            await interaction.response.send_message("Member role id set to " + str(role.id), ephemeral=True)
         else:
             await interaction.response.send_message("ID does not refer to a legit role", ephemeral=True)
-        logging.info("%s set %s as member role.", interaction.guild_id, role_id)
+        logging.info("%s set %s as member role.", interaction.guild_id, role.id)
 
 
     @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.")
     @app_commands.checks.has_permissions(administrator=True)
-    async def set_log_channel(self, interaction: discord.Interaction, channel_id: int):
-        if self.check_channel_integrity(channel_id):
-            self.db.get_server_db(interaction.guild_id).set_log_channel(channel_id)
-            logging.info("%s set %s as log channel.", interaction.guild_id, channel_id)
-            await interaction.response.send_message("Log Channel id set to " + str(channel_id), ephemeral=True)
+    async def set_log_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
+        if self.check_channel_integrity(channel.id):
+            self.db.get_server_db(interaction.guild_id).set_log_channel(channel.id)
+            logging.info("%s set %s as log channel.", interaction.guild_id, channel.id)
+            await interaction.response.send_message("Log Channel id set to " + str(channel.id), ephemeral=True)
         else:
             await interaction.response.send_message("ID does not refer to a legit channel", ephemeral=True)
             logging.info("%s used a wrong ID as log channel.", interaction.guild_id)
@@ -209,9 +209,9 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="proofchannel", description="Sets the Channel to which the threads will be attached.")
     @app_commands.checks.has_permissions(administrator=True)
-    async def set_proof_channel(self, interaction: discord.Interaction, channel_id: int):
+    async def set_proof_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         
-        channel = self.bot.get_channel(channel_id)
+        channel = self.bot.get_channel(channel.id)
         if not channel:
             await interaction.response.send_message("Please use a valid channel!", ephemeral=True)
             return
@@ -222,10 +222,10 @@ class Settings(commands.Cog):
             await interaction.response.send_message("You need to enable use_public_threads for VeraBot on your proof channel first!", ephemeral=True)
             return
 
-        self.db.get_server_db(interaction.guild_id).set_proof_channel(channel_id)
-        logging.info("%s set %s as proof channel.", interaction.guild_id, channel_id)
+        self.db.get_server_db(interaction.guild_id).set_proof_channel(channel.id)
+        logging.info("%s set %s as proof channel.", interaction.guild_id, channel.id)
 
-        await interaction.response.send_message("Proof Channel id set to " + str(channel_id), ephemeral=True)
+        await interaction.response.send_message("Proof Channel id set to " + str(channel.id), ephemeral=True)
 
 
     @app_commands.command(name="enablethreads", description="Toggles function that the bot creates a thread for each proof.")
@@ -306,7 +306,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Function only for Multi-Talent servers!")
     @app_commands.checks.has_permissions(administrator=True)
-    async def add_idol(self, interaction: discord.Interaction, name: str, log_id: int, role_id: int):
+    async def add_idol(self, interaction: discord.Interaction, name: str, log: discord.TextChannel, role: discord.Role):
         if not Utility.is_multi_server(interaction.guild_id):
             logging.info("%s: Tried to use mutli-talent ADD without having it enabled.", interaction.guild_id)
             await interaction.response.send_message("Your server has not enabled the usage of multiple talents. If you intend to use this feature, please use `$enableMultiServer` first. Otherwise `$setVtuber` is the command you wanted to use.", ephemeral=True)
@@ -319,17 +319,17 @@ class Settings(commands.Cog):
             await interaction.response.send_message("This Vtuber is already mapped to a server!", ephemeral=True)
             return
 
-        if not self.bot.get_channel(log_id):
+        if not self.bot.get_channel(log.id):
             await interaction.response.send_message("Please use a proper Channel!", ephemeral=True)
             return
 
-        if not self.check_role_integrity(interaction, role_id):
+        if not self.check_role_integrity(interaction, role.id):
             return
 
         # Finally add to db
-        self.db.get_server_db(interaction.guild_id).add_multi_talent(name, log_id, role_id)
+        self.db.get_server_db(interaction.guild_id).add_multi_talent(name, log.id, role.id)
         self.db.set_vtuber(name, interaction.guild_id)
-        logging.info("%s: Added %s with %s as Log Channel and %s as Role.", interaction.guild_id, name, log_id, role_id)
+        logging.info("%s: Added %s with %s as Log Channel and %s as Role.", interaction.guild_id, name, log.id, role.id)
 
         await interaction.response.send_message("Successfully added the new talent!", ephemeral=True)
 

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="viewsettings", description="Shows all settings of this server.")
     @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def show_settings(self, interaction: discord.Interaction):
         logging.debug("%s called viewSettings.", interaction.user.id)
 
@@ -80,6 +81,7 @@ class Settings(commands.Cog):
     @app_commands.command(name="setvtuber",
         description="Sets the name of the VTuber of this server")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
 
         # always only one entry
@@ -103,6 +105,7 @@ class Settings(commands.Cog):
     @app_commands.command(name="memberrole",
         description="Sets the role for membership content")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_member_role(self, interaction: discord.Interaction, role: discord.Role):
         if self.check_role_integrity(interaction, role.id):
             self.db.get_server_db(interaction.guild_id).set_member_role(role.id)
@@ -115,6 +118,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_log_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         if self.check_channel_integrity(channel.id):
             self.db.get_server_db(interaction.guild_id).set_log_channel(channel.id)
@@ -129,6 +133,7 @@ class Settings(commands.Cog):
     @app_commands.command(name="picture",
         description="Sets the image that is sent when a membership is about to expire.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_picture(self, interaction: discord.Interaction, link: str):
         logging.info("{} set their picture: {}".format(str(interaction.guild_id), link))
         from re import fullmatch
@@ -142,6 +147,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="setauto", description = "Sets whether the bot is allowed to automatically add the membership role.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_automatic_role(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
@@ -156,6 +162,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="setadditionalproof", description = "Sets whether the bot will require additional proof from the user.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_require_additional_proof(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
@@ -170,6 +177,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="settolerance", description = "Sets the time that users will have access to the membership channel after their membership expired.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_tolerance_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
             await interaction.response.send_message("This value needs to be at least 0 days.", ephemeral=True)
@@ -183,6 +191,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="setpriornoticeduration", description = "Set time for notice before membership expiry")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
             await interaction.response.send_message("This value needs to be at least 0 days.")
@@ -195,6 +204,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="enablelogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_logging(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
@@ -209,6 +219,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="proofchannel", description="Sets the Channel to which the threads will be attached.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def set_proof_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         
         channel = self.bot.get_channel(channel.id)
@@ -230,6 +241,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="enablethreads", description="Toggles function that the bot creates a thread for each proof.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def toggle_threads(self, interaction: discord.Interaction, flag: str):
         # multi-server cannot use threads
         if Utility.is_multi_server(interaction.guild_id):
@@ -273,6 +285,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="enablemultiserver", description="Will activate the possibility to support several talents on one server.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def enable_multi_server(self, interaction: discord.Interaction):
         if Utility.is_multi_server(interaction.guild_id):
             logging.info("%s: Tried to enable the multi-talent function again.", interaction.guild_id)
@@ -290,6 +303,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="disablemultiserver", description="Will disable the possibility to support several talents on one server.")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def disable_multi_server(self, interaction: discord.Interaction):
         if not Utility.is_multi_server(interaction.guild_id):
             logging.info("%s: Tried to disabled the multi-talent function without having it enabled.", interaction.guild_id)
@@ -306,6 +320,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Function only for Multi-Talent servers!")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def add_idol(self, interaction: discord.Interaction, name: str, log: discord.TextChannel, role: discord.Role):
         if not Utility.is_multi_server(interaction.guild_id):
             logging.info("%s: Tried to use mutli-talent ADD without having it enabled.", interaction.guild_id)
@@ -336,6 +351,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="removetalent", description="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!")
     @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.check(Utility.is_interaction_not_dm)
     async def remove_idol(self, interaction: discord.Interaction, name: str):
         if not Utility.is_multi_server(interaction.guild_id):
             logging.info("%s: Tried to remove a mutli-talent without having it enabled.", interaction.guild_id)

--- a/settings.py
+++ b/settings.py
@@ -26,16 +26,22 @@ class Settings(commands.Cog):
         server_db = self.db.get_server_db(interaction.guild_id)
 
         # VTuber
-        vtuber = server_db.get_vtuber()
-        embed.add_field(name="VTuber", value=vtuber)
+        if Utility.is_multi_server(interaction.guild_id):
+            multi_talents = server_db.get_multi_talents()
+            idols = [m['idol'] for m in multi_talents]
+            vtubers = ', '.join(idols)
+            embed.add_field(name="VTubers", value=vtubers)
+        else:
+            vtuber = server_db.get_vtuber()
+            embed.add_field(name="VTuber", value=vtuber)
 
-        # Member Role
-        member_role = server_db.get_member_role()
-        embed.add_field(name='Member Role ID', value=str(member_role), inline=True)
+            # Member Role
+            member_role = server_db.get_member_role()
+            embed.add_field(name='Member Role ID', value=str(member_role), inline=True)
 
-        # Log Channel
-        log_channel = server_db.get_log_channel()
-        embed.add_field(name='Log Channel ID', value=str(log_channel), inline=True)
+            # Log Channel
+            log_channel = server_db.get_log_channel()
+            embed.add_field(name='Log Channel ID', value=str(log_channel), inline=True)
 
         # current picture (als image anhängen)
         picture_url = server_db.get_picture()

--- a/settings.py
+++ b/settings.py
@@ -16,7 +16,7 @@ class Settings(commands.Cog):
         self.db = Database()
 
     @app_commands.command(name="viewsettings", description="Shows all settings of this server.")
-    @app_commands.checks.has_permissions(manage_messages=True)
+    @app_commands.checks.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def show_settings(self, interaction: discord.Interaction):
         logging.debug("%s called viewSettings.", interaction.user.id)
@@ -86,7 +86,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="setvtuber",
         description="Sets the name of the VTuber of this server")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
 
@@ -110,7 +110,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="memberrole",
         description="Sets the role for membership content")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_member_role(self, interaction: discord.Interaction, role: discord.Role):
         if self.check_role_integrity(interaction, role.id):
@@ -123,7 +123,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_log_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         if self.check_channel_integrity(channel.id):
@@ -138,7 +138,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="picture",
         description="Sets the image that is sent when a membership is about to expire.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_picture(self, interaction: discord.Interaction, link: str):
         logging.info("{} set their picture: {}".format(str(interaction.guild_id), link))
@@ -152,7 +152,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="setauto", description = "Sets whether the bot is allowed to automatically add the membership role.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_automatic_role(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -167,7 +167,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="setadditionalproof", description = "Sets whether the bot will require additional proof from the user.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_require_additional_proof(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -182,7 +182,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="settolerance", description = "Sets the time that users will have access to the membership channel after their membership expired.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_tolerance_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -196,7 +196,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="setpriornoticeduration", description = "Set time for notice before membership expiry")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -209,7 +209,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Users will be notified " + str(time) + " days before their membership ends.", ephemeral=True)
 
     @app_commands.command(name="enablelogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_logging(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -224,7 +224,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="proofchannel", description="Sets the Channel to which the threads will be attached.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_proof_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         
@@ -246,7 +246,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="enablethreads", description="Toggles function that the bot creates a thread for each proof.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def toggle_threads(self, interaction: discord.Interaction, flag: str):
         # multi-server cannot use threads
@@ -290,7 +290,7 @@ class Settings(commands.Cog):
         return True
 
     @app_commands.command(name="enablemultiserver", description="Will activate the possibility to support several talents on one server.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def enable_multi_server(self, interaction: discord.Interaction):
         if Utility.is_multi_server(interaction.guild_id):
@@ -308,7 +308,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Management of several talents was activated for this server!", ephemeral=True)
 
     @app_commands.command(name="disablemultiserver", description="Will disable the possibility to support several talents on one server.")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def disable_multi_server(self, interaction: discord.Interaction):
         if not Utility.is_multi_server(interaction.guild_id):
@@ -325,7 +325,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Function only for Multi-Talent servers!")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def add_idol(self, interaction: discord.Interaction, name: str, log: discord.TextChannel, role: discord.Role):
         if not Utility.is_multi_server(interaction.guild_id):
@@ -356,7 +356,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="removetalent", description="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!")
-    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.checks.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def remove_idol(self, interaction: discord.Interaction, name: str):
         if not Utility.is_multi_server(interaction.guild_id):

--- a/settings.py
+++ b/settings.py
@@ -78,7 +78,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="setvtuber",
         description="Sets the name of the VTuber of this server.\nThe screenshot sent for the verification is scanned for this name. Therefore this name should be identical with the name in the membership tab.")
-    @app_commands.check.has_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
     async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
 
         # always only one entry

--- a/settings.py
+++ b/settings.py
@@ -78,7 +78,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message(content=m, embed = embed, ephemeral=True)
 
     @app_commands.command(name="setvtuber",
-        description="Sets the name of the VTuber of this server.\nThe screenshot sent for the verification is scanned for this name. Therefore this name should be identical with the name in the membership tab.")
+        description="Sets the name of the VTuber of this server")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
 
@@ -101,7 +101,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="memberrole",
-        description="Sets the role that should be given to a member who has proven that he has valid access to membership content.\nRequires the ID not the role name or anything else!")
+        description="Sets the role for membership content")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_member_role(self, interaction: discord.Interaction, role_id: int):
         if self.check_role_integrity(interaction, role_id):
@@ -113,7 +113,7 @@ class Settings(commands.Cog):
         logging.info("%s set %s as member role.", interaction.guild_id, role_id)
 
 
-    @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.\nRequires the ID not the role name or anything else!")
+    @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_log_channel(self, interaction: discord.Interaction, channel_id: int):
         if self.check_channel_integrity(channel_id):
@@ -127,7 +127,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="picture",
-        description="Sets the image that is sent when a membership is about to expire. It supports link that end with png, jpg or jpeg.")
+        description="Sets the image that is sent when a membership is about to expire.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_picture(self, interaction: discord.Interaction, link: str):
         logging.info("{} set their picture: {}".format(str(interaction.guild_id), link))
@@ -140,7 +140,7 @@ class Settings(commands.Cog):
             await interaction.response.send_message("Please send a legit link. Only jpg, jpeg and png are accepted.", ephemeral=True)
 
 
-    @app_commands.command(name="setauto", description = "Sets whether the bot is allowed to automatically add the membership role. Only allows True or False as input.")
+    @app_commands.command(name="setauto", description = "Sets whether the bot is allowed to automatically add the membership role.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_automatic_role(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -154,7 +154,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Flag for automatic role handling set to " + str(flag), ephemeral=True)
 
 
-    @app_commands.command(name="setadditionalproof", description = "Sets whether the bot will require additional proof from the user. Only allows True or False as input.")
+    @app_commands.command(name="setadditionalproof", description = "Sets whether the bot will require additional proof from the user.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_require_additional_proof(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -181,7 +181,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Time that users will still have access to the channel after their membership expired set to {} days.".format(str(time)), ephemeral=True)
 
 
-    @app_commands.command(name="setpriornoticeduration", description = "Sets how many days before the expiry of their membership a user will be notified to renew their proof.")
+    @app_commands.command(name="setpriornoticeduration", description = "Set time for notice before membership expiry")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -228,9 +228,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Proof Channel id set to " + str(channel_id), ephemeral=True)
 
 
-    @app_commands.command(name="enablethreads", 
-    description="Will activate the use of threads. The bot will create a Thread for each submitted proof. The log channel will be used to protocol the verified/denied proofs, not as place to verify them anymore. " +
-    "Requires a proof channel to be set and use_public_threads to be enabled for this channel.")
+    @app_commands.command(name="enablethreads", description="Toggles function that the bot creates a thread for each proof.")
     @app_commands.checks.has_permissions(administrator=True)
     async def toggle_threads(self, interaction: discord.Interaction, flag: str):
         # multi-server cannot use threads
@@ -306,7 +304,7 @@ class Settings(commands.Cog):
     
 
 
-    @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Also needs the log channel and role id. Function only for Multi-Talent servers!")
+    @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Function only for Multi-Talent servers!")
     @app_commands.checks.has_permissions(administrator=True)
     async def add_idol(self, interaction: discord.Interaction, name: str, log_id: int, role_id: int):
         if not Utility.is_multi_server(interaction.guild_id):

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,7 @@
 # External
 from database import Database
 import discord
+from discord import app_commands
 from discord.ext import commands
 # Python
 import logging
@@ -13,26 +14,18 @@ class Settings(commands.Cog):
         self.bot = bot
         self.db = Database()
 
-    @commands.command(name="viewSettings", aliases=["settings", "allSettings", "showSettings"],
-        help="Shows all settings of this server.",
-        brief="Shows all settings")
-    @commands.has_permissions(manage_messages=True)
-    @commands.guild_only()
-    async def show_settings(self, ctx):
-        logging.debug("%s called viewSettings.", ctx.author.id)
+    @app_commands.command(name="viewSettings", description="Shows all settings of this server.")
+    @app_commands.checks.has_permissions(manage_messages=True)
+    async def show_settings(self, interaction: discord.Interaction):
+        logging.debug("%s called viewSettings.", interaction.user.id)
 
         title = "Current Settings"
         embed = discord.Embed(title = title, description = None)
-        server_db = self.db.get_server_db(ctx.guild.id)
+        server_db = self.db.get_server_db(interaction.guild_id)
 
         # VTuber
         vtuber = server_db.get_vtuber()
         embed.add_field(name="VTuber", value=vtuber)
-        
-        #get prefixes
-        prefixes = server_db.get_prefixes()
-        prefixes = ', '.join(element for element in prefixes)
-        embed.add_field(name='Prefixes', value=prefixes, inline=True)
 
         # Member Role
         member_role = server_db.get_member_role()
@@ -75,72 +68,28 @@ class Settings(commands.Cog):
         embed.add_field(name='Proof Channel ID', value=str(proof_channel), inline=True)
         
         # is multi server
-        is_multi = Utility.is_multi_server(ctx.guild.id)
+        is_multi = Utility.is_multi_server(interaction.guild_id)
         embed.add_field(name='Multi Server', value=str(is_multi), inline=True)
 
         m = "These are your current settings.\nYour set expiration image is the picture.\n"
         m += "For a full explanation of the settings please refer to:\n"
         m += "<https://github.com/nonJerry/VeraBot/blob/master/settings.md>"
-        await ctx.send(content=m, embed = embed)
+        await interaction.response.send_message(content=m, embed = embed, ephemeral=True)
 
-    @commands.command(name="prefix",
-        help="Adds the <prefix> that can be used for the bot on this server.",
-        brief="Adds an additional prefix")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_prefix(self, ctx, prefix: str):
-        self.db.get_server_db(ctx.guild.id).set_prefix(prefix)
-
-        await ctx.send("Prefix " + prefix + " added")
-        logging.debug("%s added %s as prefix.", ctx.guild.id, prefix)
-
-    @set_prefix.error
-    async def prefix_error(self, ctx, error):
-        if isinstance(error, commands.BadArgument) or isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send('The argument is invalid')
-
-
-    @commands.command(name="removePrefix",
-        help="Removes the <prefix> so that it is not available as a prefix anymore for this server.",
-        brief="Removes an prefix")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def remove_prefix(self, ctx, prefix: str):
-
-        if self.db.get_server_db(ctx.guild.id).remove_prefix(prefix) == 0:
-            await ctx.send("Prefix not found")
-        else:
-            await ctx.send(prefix +" removed")
-        logging.debug("%s removed %s as prefix.", ctx.guild.id, prefix)
-
-
-    @commands.command(name="showPrefix", aliases=["viewPrefix", "showPrefixes", "viewPrefixes"],
-        help="Shows all prefixes that are available to use commands of this bot on this server.",
-        brief="Shows all prefixes")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def show_prefix(self, ctx):
-
-        await ctx.send("Those prefixes are set: " + str(self.db.get_server_db(ctx.guild.id).get_prefixes()))
-        logging.debug("%s viewed their prefixes.", ctx.guild.id)
-
-
-    @commands.command(name="setVTuber",
-        help="Sets the name of the VTuber of this server.\nThe screenshot sent for the verification is scanned for this name. Therefore this name should be identical with the name in the membership tab.",
-        brief="Sets the name of the VTuber of this server")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_idol(self, ctx, vtuber_name: str):
+    @app_commands.command(name="setVTuber",
+        description="Sets the name of the VTuber of this server.\nThe screenshot sent for the verification is scanned for this name. Therefore this name should be identical with the name in the membership tab.")
+    @app_commands.check.has_permissions(administrator=True)
+    async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
 
         # always only one entry
         if self.check_vtuber(vtuber_name):           
-            await ctx.send("This Vtuber is already mapped to a server!")
+            await interaction.response.send_message("This Vtuber is already mapped to a server!")
             return
 
-        self.db.set_vtuber(vtuber_name, ctx.guild.id)
+        self.db.set_vtuber(vtuber_name, interaction.guild_id)
 
-        await ctx.send("Set VTuber name to " + vtuber_name)
-        logging.info("%s (%s) -> New Vtuber added: %s", ctx.guild.name, ctx.guild.id, vtuber_name)
+        await interaction.response.send_message("Set VTuber name to " + vtuber_name, ephemeral=True)
+        logging.info("%s (%s) -> New Vtuber added: %s", interaction.guild.name, interaction.guild_id, vtuber_name)
 
     def check_vtuber(self, vtuber_name) -> bool:
         for element in self.db.get_vtuber_list():
@@ -150,196 +99,166 @@ class Settings(commands.Cog):
         return False
 
 
-    @commands.command(name="memberRole", aliases=["setMemberRole"],
-        help="Sets the role that should be given to a member who has proven that he has valid access to membership content.\nRequires the ID not the role name or anything else!",
-        brief="Sets the role for membership content")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_member_role(self, ctx, role_id: int):
-        if self.check_role_integrity(ctx, role_id):
-            self.db.get_server_db(ctx.guild.id).set_member_role(role_id)
+    @app_commands.command(name="memberRole",
+        description="Sets the role that should be given to a member who has proven that he has valid access to membership content.\nRequires the ID not the role name or anything else!")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_member_role(self, interaction: discord.Interaction, role_id: int):
+        if self.check_role_integrity(interaction, role_id):
+            self.db.get_server_db(interaction.guild_id).set_member_role(role_id)
 
-            await ctx.send("Member role id set to " + str(role_id))
+            await interaction.response.send_message("Member role id set to " + str(role_id), ephemeral=True)
         else:
-            await ctx.send("ID does not refer to a legit role")
-        logging.info("%s set %s as member role.", ctx.guild.id, role_id)
+            await interaction.response.send_message("ID does not refer to a legit role", ephemeral=True)
+        logging.info("%s set %s as member role.", interaction.guild_id, role_id)
 
 
-    @commands.command(name="logChannel", aliases=["setLogChannel"],
-        help="Sets the channel which is used to control the sent memberships.\nRequires the ID not the role name or anything else!",
-        brief="Sets the channel for logging")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_log_channel(self, ctx, channel_id: int):
+    @app_commands.command(name="logChannel", description="Sets the channel which is used to control the sent memberships.\nRequires the ID not the role name or anything else!")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_log_channel(self, interaction: discord.Interaction, channel_id: int):
         if self.check_channel_integrity(channel_id):
-            self.db.get_server_db(ctx.guild.id).set_log_channel(channel_id)
-            logging.info("%s set %s as log channel.", ctx.guild.id, channel_id)
-            await ctx.send("Log Channel id set to " + str(channel_id))
+            self.db.get_server_db(interaction.guild_id).set_log_channel(channel_id)
+            logging.info("%s set %s as log channel.", interaction.guild_id, channel_id)
+            await interaction.response.send_message("Log Channel id set to " + str(channel_id), ephemeral=True)
         else:
-            await ctx.send("ID does not refer to a legit channel")
-            logging.info("%s used a wrong ID as log channel.", ctx.guild.id)
+            await interaction.response.send_message("ID does not refer to a legit channel", ephemeral=True)
+            logging.info("%s used a wrong ID as log channel.", interaction.guild_id)
 
 
 
-    @commands.command(name="picture", aliases=["setPicture"],
-        help="Sets the image that is sent when a membership is about to expire.\n" +
-        "It supports link that end with png, jpg or jpeg.",
-        brief="Set image for expiration message.")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_picture(self, ctx, link: str):
-        logging.info("{} set their picture: {}".format(str(ctx.guild.id), link))
+    @app_commands.command(name="picture",
+        description="Sets the image that is sent when a membership is about to expire. It supports link that end with png, jpg or jpeg.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_picture(self, interaction: discord.Interaction, link: str):
+        logging.info("{} set their picture: {}".format(str(interaction.guild_id), link))
         from re import fullmatch
         match = fullmatch(r"http[s]?://[a-zA-Z0-9\_\-\.]+/[a-zA-Z0-9\_\-/]+\.(png|jpeg|jpg)", link)
         if match:
-            self.db.get_server_db(ctx.guild.id).set_picture(link)
-            await ctx.send("Image for expiration message set.")
+            self.db.get_server_db(interaction.guild_id).set_picture(link)
+            await interaction.response.send_message("Image for expiration message set.", ephemeral=True)
         else:
-            await ctx.send("Please send a legit link. Only jpg, jpeg and png are accepted.")
+            await interaction.response.send_message("Please send a legit link. Only jpg, jpeg and png are accepted.", ephemeral=True)
 
 
-    @commands.command(name="setAuto", aliases=["auto", "setAutoRole", "setAutomaticRole"],
-        help = "Sets whether the bot is allowed to automatically add the membership role.\n"
-        + "Only allows True or False as input.",
-        brief = "Set flag for automatic role handling")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_automatic_role(self, ctx, flag: str):
+    @app_commands.command(name="setAuto", description = "Sets whether the bot is allowed to automatically add the membership role. Only allows True or False as input.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_automatic_role(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
-            await ctx.send(self.BOOLEAN_ONLY_TEXT)
+            await interaction.response.send_message(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
 
-        self.db.get_server_db(ctx.guild.id).set_automatic(flag)
-        logging.info("%s set auto to %s", ctx.guild.id, str(flag))
+        self.db.get_server_db(interaction.guild_id).set_automatic(flag)
+        logging.info("%s set auto to %s", interaction.guild_id, str(flag))
 
-        await ctx.send("Flag for automatic role handling set to " + str(flag))
+        await interaction.response.send_message("Flag for automatic role handling set to " + str(flag), ephemeral=True)
 
 
-    @commands.command(name="setAdditionalProof", aliases=["setProof", "setRequireProof", "additionalProof", "requireAdditionalProof"],
-        help = "Sets whether the bot will require additional proof from the user.\n"
-        + "Only allows True or False as input.",
-        brief = "Set flag for the inquiry of additional Proof")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_require_additional_proof(self, ctx, flag: str):
+    @app_commands.command(name="setAdditionalProof", description = "Sets whether the bot will require additional proof from the user. Only allows True or False as input.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_require_additional_proof(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
-            await ctx.send(self.BOOLEAN_ONLY_TEXT)
+            await interaction.response.send_message(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
 
-        self.db.get_server_db(ctx.guild.id).set_additional_proof(flag)
-        logging.info("%s set additional Proof to %s", ctx.guild.id, str(flag))
+        self.db.get_server_db(interaction.guild_id).set_additional_proof(flag)
+        logging.info("%s set additional Proof to %s", interaction.guild_id, str(flag))
 
-        await ctx.send("Flag for additional Proof set to " + str(flag))
+        await interaction.response.send_message("Flag for additional Proof set to " + str(flag), ephemeral=True)
 
 
-    @commands.command(name="setTolerance", aliases=["tolerance", "toleranceDuration"],
-        help = "Sets the time that users will have access to the membership channel after their membership expired.",
-        brief = "Set tolerance time after membership expiry")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_tolerance_duration(self, ctx, time: int):
+    @app_commands.command(name="setTolerance", description = "Sets the time that users will have access to the membership channel after their membership expired.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_tolerance_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
-            await ctx.send("This value needs to be at least 0 days.")
+            await interaction.response.send_message("This value needs to be at least 0 days.", ephemeral=True)
             return
 
-        self.db.get_server_db(ctx.guild.id).set_tolerance_duration(time)
-        logging.info("%s set Tolerance to %s", ctx.guild.id, time)
+        self.db.get_server_db(interaction.guild_id).set_tolerance_duration(time)
+        logging.info("%s set Tolerance to %s", interaction.guild_id, time)
 
-        await ctx.send("Time that users will still have access to the channel after their membership expired set to {} days.".format(str(time)))
+        await interaction.response.send_message("Time that users will still have access to the channel after their membership expired set to {} days.".format(str(time)), ephemeral=True)
 
 
-    @commands.command(name="setPriorNoticeDuration", aliases=["informDuration", "PriorNoticeDuration", "PriorNotice", "setPriorNotice"],
-        help = "Sets how many days before the expiry of their membership a user will be notified to renew their proof.",
-        brief = "Set time for notice before membership expiry")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_inform_duration(self, ctx, time: int):
+    @app_commands.command(name="setPriorNoticeDuration", description = "Sets how many days before the expiry of their membership a user will be notified to renew their proof.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
-            await ctx.send("This value needs to be at least 0 days.")
+            await interaction.response.send_message("This value needs to be at least 0 days.")
             return
 
-        self.db.get_server_db(ctx.guild.id).set_inform_duration(time)
-        logging.info("%s set prior Notice to %s", ctx.guild.id, time)
+        self.db.get_server_db(interaction.guild_id).set_inform_duration(time)
+        logging.info("%s set prior Notice to %s", interaction.guild_id, time)
 
-        await ctx.send("Users will be notified " + str(time) + " days before their membership ends.")
+        await interaction.response.send_message("Users will be notified " + str(time) + " days before their membership ends.", ephemeral=True)
 
-    @commands.command(name="enableLogging",
-        help="Flag which decides whether you will see the logs when the bot checks for expired memberships.",
-        brief="Toggles logging regarding expired memberships")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_logging(self, ctx, flag):
+    @app_commands.command(name="enableLogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_logging(self, interaction: discord.Interaction, flag):
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
-            await ctx.send(self.BOOLEAN_ONLY_TEXT)
+            await interaction.response.send_message(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
         
-        self.db.get_server_db(ctx.guild.id).set_logging(flag)
-        logging.info("%s set logging to %s", ctx.guild.id, str(flag))
+        self.db.get_server_db(interaction.guild_id).set_logging(flag)
+        logging.info("%s set logging to %s", interaction.guild_id, str(flag))
 
-        await ctx.send("Flag for logging set to " + str(flag))
+        await interaction.response.send_message("Flag for logging set to " + str(flag), ephemeral=True)
 
 
-    @commands.command(name="proofChannel", aliases=["setProofChannel", "threadChannel", "setThreadChannel"],
-    help="Sets the Channel to which the threads will be attached.",
-    brief="Sets the Channel to which the threads will be attached.")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def set_proof_channel(self, ctx, channel_id: int):
+    @app_commands.command(name="proofChannel", description="Sets the Channel to which the threads will be attached.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_proof_channel(self, interaction: discord.Interaction, channel_id: int):
         
         channel = self.bot.get_channel(channel_id)
         if not channel:
-            await ctx.send("Please use a valid channel!")
+            await interaction.response.send_message("Please use a valid channel!", ephemeral=True)
             return
 
         #check whether use_public_thread is allowed
         permissions = channel.permissions_for(channel.guild.me)
         if not permissions.create_public_threads:
-            await ctx.send("You need to enable use_public_threads for VeraBot on your proof channel first!")
+            await interaction.response.send_message("You need to enable use_public_threads for VeraBot on your proof channel first!", ephemeral=True)
             return
 
-        self.db.get_server_db(ctx.guild.id).set_proof_channel(channel_id)
-        logging.info("%s set %s as proof channel.", ctx.guild.id, channel_id)
+        self.db.get_server_db(interaction.guild_id).set_proof_channel(channel_id)
+        logging.info("%s set %s as proof channel.", interaction.guild_id, channel_id)
 
-        await ctx.send("Proof Channel id set to " + str(channel_id))
+        await interaction.response.send_message("Proof Channel id set to " + str(channel_id), ephemeral=True)
 
 
-    @commands.command(name="enableThreads", aliases=["threads", "enabledThread", "thread"],
-    help="Will activate the use of threads. The bot will create a Thread for each submitted proof. The log channel will be used to protocol the verified/denied proofs, not as place to verify them anymore.\n" +
-    "Requires a proof channel to be set and use_public_threads to be enabled for this channel.",
-    brief="Toggles function that the bot creates a thread for each proof.")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def toggle_threads(self, ctx, flag):
+    @app_commands.command(name="enableThreads", 
+    description="Will activate the use of threads. The bot will create a Thread for each submitted proof. The log channel will be used to protocol the verified/denied proofs, not as place to verify them anymore. " +
+    "Requires a proof channel to be set and use_public_threads to be enabled for this channel.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def toggle_threads(self, interaction: discord.Interaction, flag):
         # multi-server cannot use threads
-        if Utility.is_multi_server(ctx.guild.id):
-            await ctx.send("You cannot enable threads as mutli-server!")
-            logging.info("%s tried to enable Threads as multi-server.", ctx.guild.id)
+        if Utility.is_multi_server(interaction.guild_id):
+            await interaction.response.send_message("You cannot enable threads as mutli-server!", ephemeral=True)
+            logging.info("%s tried to enable Threads as multi-server.", interaction.guild_id)
             return
 
         flag = Utility.text_to_boolean(flag)
         if not isinstance(flag, bool):
-            await ctx.send(self.BOOLEAN_ONLY_TEXT)
+            await interaction.response.send_message(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
 
         if flag:
-            channel = self.bot.get_channel(self.db.get_server_db(ctx.guild.id).get_proof_channel())
+            channel = self.bot.get_channel(self.db.get_server_db(interaction.guild_id).get_proof_channel())
             if not channel:
-                await ctx.send("Please set a proof channel first!")
+                await interaction.response.send_message("Please set a proof channel first!", ephemeral=True)
                 return
 
             #check whether use_public_thread is allowed
             permissions = channel.permissions_for(channel.guild.me)
             if not permissions.create_public_threads:
-                await ctx.send("You need to enable use_public_threads for VeraBot on your proof channel first!")
+                await interaction.response.send_message("You need to enable use_public_threads for VeraBot on your proof channel first!", ephemeral=True)
                 return
         # set value
-        self.db.get_server_db(ctx.guild.id).set_threads_enabled(flag)
-        logging.info("%s set threads to %s", ctx.guild.id, str(flag))
+        self.db.get_server_db(interaction.guild_id).set_threads_enabled(flag)
+        logging.info("%s set threads to %s", interaction.guild_id, str(flag))
 
-        await ctx.send("Flag for using threads set to " + str(flag))
+        await interaction.response.send_message("Flag for using threads set to " + str(flag), ephemeral=True)
 
     async def check_thread_permissions(self, guild_id: int) -> bool:
         if Utility.is_multi_server(guild_id):
@@ -353,100 +272,88 @@ class Settings(commands.Cog):
             return False
         return True
 
-    @commands.command(name="enableMultiServer", aliases=["enableMulti"],
-    help="Will activate the possibility to support several talents on one server.",
-    brief="Will activate the possibility to support several talents on one server.")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def enable_multi_server(self, ctx):
-        if Utility.is_multi_server(ctx.guild.id):
-            logging.info("%s: Tried to enable the multi-talent function again.", ctx.guild.id)
-            await ctx.send("Your server already has enabled the usage of multiple talents!")
+    @app_commands.command(name="enableMultiServer", description="Will activate the possibility to support several talents on one server.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def enable_multi_server(self, interaction: discord.Interaction):
+        if Utility.is_multi_server(interaction.guild_id):
+            logging.info("%s: Tried to enable the multi-talent function again.", interaction.guild_id)
+            await interaction.response.send_message("Your server already has enabled the usage of multiple talents!", ephemeral=True)
             return
-        if self.db.get_server_db(ctx.guild.id).get_threads_enabled():
-            await ctx.send("You cannot enable multi server with threads enabled!")
-            logging.info("%s: Tried to enable the multi-talent function with threads enabled.", ctx.guild.id)
+        if self.db.get_server_db(interaction.guild_id).get_threads_enabled():
+            await interaction.response.send_message("You cannot enable multi server with threads enabled!", ephemeral=True)
+            logging.info("%s: Tried to enable the multi-talent function with threads enabled.", interaction.guild_id)
             return
 
-        self.db.add_multi_server(ctx.guild.id)
-        logging.info("%s: Enabled the multi-talent function.", ctx.guild.id)
+        self.db.add_multi_server(interaction.guild_id)
+        logging.info("%s: Enabled the multi-talent function.", interaction.guild_id)
 
-        await ctx.send("Management of several talents was activated for this server!")
+        await interaction.response.send_message("Management of several talents was activated for this server!", ephemeral=True)
 
-    @commands.command(name="disableMultiServer", aliases=["disableMulti"],
-    help="Will disable the possibility to support several talents on one server.",
-    brief="Will disable the possibility to support several talents on one server.")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def disable_multi_server(self, ctx):
-        if not Utility.is_multi_server(ctx.guild.id):
-            logging.info("%s: Tried to disabled the multi-talent function without having it enabled.", ctx.guild.id)
-            await ctx.send("Your server has not enabled the usage of multiple talents!")
+    @app_commands.command(name="disableMultiServer", description="Will disable the possibility to support several talents on one server.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def disable_multi_server(self, interaction: discord.Interaction):
+        if not Utility.is_multi_server(interaction.guild_id):
+            logging.info("%s: Tried to disabled the multi-talent function without having it enabled.", interaction.guild_id)
+            await interaction.response.send_message("Your server has not enabled the usage of multiple talents!", ephemeral=True)
             return
         
-        self.db.remove_multi_server(ctx.guild.id)
-        logging.info("%s: Disabled the multi-talent function.", ctx.guild.id)
+        self.db.remove_multi_server(interaction.guild_id)
+        logging.info("%s: Disabled the multi-talent function.", interaction.guild_id)
 
-        await ctx.send("Management of several talents was disabled for this server! For this all added VTubers were removed. Please add the one wanted again using $setVtuber")
+        await interaction.response.send_message("Management of several talents was disabled for this server! For this all added VTubers were removed. Please add the one wanted again using $setVtuber", ephemeral=True)
 
     
 
 
-    @commands.command(name="addTalent", aliases=["addVTuber", "addIdol"],
-    help="Adds new Talent to be supported. Also needs the log channel and role id. Function only for Multi-Talent servers!",
-    brief="Adds new Talent to be supported. Function only for Multi-Talent servers!")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def add_idol(self, ctx, name: str, log_id: int, role_id: int):
-        if not Utility.is_multi_server(ctx.guild.id):
-            logging.info("%s: Tried to use mutli-talent ADD without having it enabled.", ctx.guild.id)
-            await ctx.send("Your server has not enabled the usage of multiple talents. If you intend to use this feature, please use `$enableMultiServer` first. Otherwise `$setVtuber` is the command you wanted to use.")
+    @app_commands.command(name="addTalent", description="Adds new Talent to be supported. Also needs the log channel and role id. Function only for Multi-Talent servers!")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def add_idol(self, interaction: discord.Interaction, name: str, log_id: int, role_id: int):
+        if not Utility.is_multi_server(interaction.guild_id):
+            logging.info("%s: Tried to use mutli-talent ADD without having it enabled.", interaction.guild_id)
+            await interaction.response.send_message("Your server has not enabled the usage of multiple talents. If you intend to use this feature, please use `$enableMultiServer` first. Otherwise `$setVtuber` is the command you wanted to use.", ephemeral=True)
             return
-        logging.info("Multi-Server %s: Trying to add %s as talent.", ctx.guild.id, name)
+        logging.info("Multi-Server %s: Trying to add %s as talent.", interaction.guild_id, name)
 
         # Check for integrity
         if self.check_vtuber(name):       
-            logging.info("%s: Talent %s already exists.", ctx.guild.id, name)   
-            await ctx.send("This Vtuber is already mapped to a server!")
+            logging.info("%s: Talent %s already exists.", interaction.guild_id, name)   
+            await interaction.response.send_message("This Vtuber is already mapped to a server!", ephemeral=True)
             return
 
         if not self.bot.get_channel(log_id):
-            await ctx.send("Please use a proper Channel!")
+            await interaction.response.send_message("Please use a proper Channel!", ephemeral=True)
             return
 
-        if not self.check_role_integrity(ctx, role_id):
+        if not self.check_role_integrity(interaction, role_id):
             return
 
         # Finally add to db
-        self.db.get_server_db(ctx.guild.id).add_multi_talent(name, log_id, role_id)
-        self.db.set_vtuber(name, ctx.guild.id)
-        logging.info("%s: Added %s with %s as Log Channel and %s as Role.", ctx.guild.id, name, log_id, role_id)
+        self.db.get_server_db(interaction.guild_id).add_multi_talent(name, log_id, role_id)
+        self.db.set_vtuber(name, interaction.guild_id)
+        logging.info("%s: Added %s with %s as Log Channel and %s as Role.", interaction.guild_id, name, log_id, role_id)
 
-        await ctx.send("Successfully added the new talent!")
+        await interaction.response.send_message("Successfully added the new talent!", ephemeral=True)
 
 
-    @commands.command(name="removeTalent", aliases=["removeVTuber", "removeIdol"],
-    help="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!",
-    brief="Removes the Talent. Function only for Multi-Talent servers!")
-    @commands.has_permissions(administrator=True)
-    @commands.guild_only()
-    async def remove_idol(self, ctx, name: str):
-        if not Utility.is_multi_server(ctx.guild.id):
-            logging.info("%s: Tried to remove a mutli-talent without having it enabled.", ctx.guild.id)
-            await ctx.send("Your server has not enabled the usage of multiple talents.")
+    @app_commands.command(name="removeTalent", description="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def remove_idol(self, interaction: discord.Interaction, name: str):
+        if not Utility.is_multi_server(interaction.guild_id):
+            logging.info("%s: Tried to remove a mutli-talent without having it enabled.", interaction.guild_id)
+            await interaction.response.send_message("Your server has not enabled the usage of multiple talents.", ephemeral=True)
             return
-        if self.db.get_server_db(ctx.guild.id).remove_multi_talent(name):
-            self.db.remove_multi_talent_vtuber(ctx.guild.id, name)
+        if self.db.get_server_db(interaction.guild_id).remove_multi_talent(name):
+            self.db.remove_multi_talent_vtuber(interaction.guild_id, name)
             logging.info("Removed %s from VTuber list", name)
-            await ctx.send("Successfully removed {}!".format(name))
+            await interaction.response.send_message("Successfully removed {}!".format(name), ephemeral=True)
         else:
-            await ctx.send("Could not remove {}!".format(name))
+            await interaction.response.send_message("Could not remove {}!".format(name), ephemeral=True)
+
+# todo: remove these command errors (should no longer be needed with slash commands auto-complete feature)
 
     @set_idol.error
     @set_log_channel.error
     @set_member_role.error
-    @set_prefix.error
-    @remove_prefix.error
     @set_automatic_role.error
     @set_require_additional_proof.error
     @set_tolerance_duration.error
@@ -459,16 +366,16 @@ class Settings(commands.Cog):
     @disable_multi_server.error
     @add_idol.error
     #@toggle_threads.error
-    async def general_error(self, ctx, error):
+    async def general_error(self, interaction: discord.Interaction, error):
         if isinstance(error, commands.BadArgument):
-            logging.debug("%s used invalid ID for %s", ctx.author.id, ctx.command)
-            await ctx.send("Please provide a valid id!")
+            logging.debug("%s used invalid ID for %s", interaction.user.id, interaction.command)
+            await interaction.response.send_message("Please provide a valid id!")
         elif isinstance(error, commands.MissingRequiredArgument):
-            logging.debug("%s forgot argument for %s", ctx.author.id, ctx.command)
-            await ctx.send("Please include the argument!")
+            logging.debug("%s forgot argument for %s", interaction.user.id, interaction.command)
+            await interaction.response.send_message("Please include the argument!")
 
-    def check_role_integrity(self, ctx, role_id: int):
-        if ctx.guild.get_role(role_id):
+    def check_role_integrity(self, interaction: discord.Interaction, role_id: int):
+        if interaction.guild.get_role(role_id):
             return True
         return False
 
@@ -477,6 +384,8 @@ class Settings(commands.Cog):
         if not channel:
             return False
         return True
+
+# hidden commands are not possible with slash commands (todo: figure out what to do with these)
 
     @commands.command(hidden = True, name = "createNewSetting")
     @commands.is_owner()

--- a/settings.py
+++ b/settings.py
@@ -16,7 +16,7 @@ class Settings(commands.Cog):
         self.db = Database()
 
     @app_commands.command(name="viewsettings", description="Shows all settings of this server.")
-    @app_commands.checks.default_permissions(manage_messages=True)
+    @app_commands.default_permissions(manage_messages=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def show_settings(self, interaction: discord.Interaction):
         logging.debug("%s called viewSettings.", interaction.user.id)
@@ -86,7 +86,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="setvtuber",
         description="Sets the name of the VTuber of this server")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_idol(self, interaction: discord.Interaction, vtuber_name: str):
 
@@ -110,7 +110,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="memberrole",
         description="Sets the role for membership content")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_member_role(self, interaction: discord.Interaction, role: discord.Role):
         if self.check_role_integrity(interaction, role.id):
@@ -123,7 +123,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_log_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         if self.check_channel_integrity(channel.id):
@@ -138,7 +138,7 @@ class Settings(commands.Cog):
 
     @app_commands.command(name="picture",
         description="Sets the image that is sent when a membership is about to expire.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_picture(self, interaction: discord.Interaction, link: str):
         logging.info("{} set their picture: {}".format(str(interaction.guild_id), link))
@@ -152,7 +152,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="setauto", description = "Sets whether the bot is allowed to automatically add the membership role.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_automatic_role(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -167,7 +167,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="setadditionalproof", description = "Sets whether the bot will require additional proof from the user.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_require_additional_proof(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -182,7 +182,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="settolerance", description = "Sets the time that users will have access to the membership channel after their membership expired.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_tolerance_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -196,7 +196,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="setpriornoticeduration", description = "Set time for notice before membership expiry")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_inform_duration(self, interaction: discord.Interaction, time: int):
         if(time < 0):
@@ -209,7 +209,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Users will be notified " + str(time) + " days before their membership ends.", ephemeral=True)
 
     @app_commands.command(name="enablelogging", description="Flag which decides whether you will see the logs when the bot checks for expired memberships.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_logging(self, interaction: discord.Interaction, flag: str):
         flag = Utility.text_to_boolean(flag)
@@ -224,7 +224,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="proofchannel", description="Sets the Channel to which the threads will be attached.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def set_proof_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         
@@ -246,7 +246,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="enablethreads", description="Toggles function that the bot creates a thread for each proof.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def toggle_threads(self, interaction: discord.Interaction, flag: str):
         # multi-server cannot use threads
@@ -290,7 +290,7 @@ class Settings(commands.Cog):
         return True
 
     @app_commands.command(name="enablemultiserver", description="Will activate the possibility to support several talents on one server.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def enable_multi_server(self, interaction: discord.Interaction):
         if Utility.is_multi_server(interaction.guild_id):
@@ -308,7 +308,7 @@ class Settings(commands.Cog):
         await interaction.response.send_message("Management of several talents was activated for this server!", ephemeral=True)
 
     @app_commands.command(name="disablemultiserver", description="Will disable the possibility to support several talents on one server.")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def disable_multi_server(self, interaction: discord.Interaction):
         if not Utility.is_multi_server(interaction.guild_id):
@@ -325,7 +325,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="addtalent", description="Adds new Talent to be supported. Function only for Multi-Talent servers!")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def add_idol(self, interaction: discord.Interaction, name: str, log: discord.TextChannel, role: discord.Role):
         if not Utility.is_multi_server(interaction.guild_id):
@@ -356,7 +356,7 @@ class Settings(commands.Cog):
 
 
     @app_commands.command(name="removetalent", description="Removes the Talent. Requires the exact name. Function only for Multi-Talent servers!")
-    @app_commands.checks.default_permissions(administrator=True)
+    @app_commands.default_permissions(administrator=True)
     @app_commands.check(Utility.is_interaction_not_dm)
     async def remove_idol(self, interaction: discord.Interaction, name: str):
         if not Utility.is_multi_server(interaction.guild_id):

--- a/settings.py
+++ b/settings.py
@@ -359,8 +359,6 @@ class Settings(commands.Cog):
             return False
         return True
 
-# hidden commands are not possible with slash commands (todo: figure out what to do with these)
-
     @commands.command(hidden = True, name = "createNewSetting")
     @commands.is_owner()
     async def create_new_setting(self, ctx, kind: str, value):

--- a/utility.py
+++ b/utility.py
@@ -161,6 +161,6 @@ class Utility:
     @classmethod
     def is_interaction_not_dm(cls, interaction: discord.Interaction) -> bool:
         if isinstance(interaction.channel, discord.PartialMessageable):
-            # reaching here means it's a DM
-            return False
+            if interaction.channel.type is discord.ChannelType.private:
+                return False
         return True

--- a/utility.py
+++ b/utility.py
@@ -1,5 +1,4 @@
 #External
-from random import paretovariate
 import discord
 from dateparser.search import search_dates
 #Python

--- a/utility.py
+++ b/utility.py
@@ -161,5 +161,6 @@ class Utility:
     @classmethod
     def is_interaction_not_dm(cls, interaction: discord.Interaction) -> bool:
         if isinstance(interaction.channel, discord.PartialMessageable):
-            return interaction.channel.type != private
+            # reaching here means it's a DM
+            return False
         return True

--- a/utility.py
+++ b/utility.py
@@ -1,4 +1,5 @@
 #External
+from random import paretovariate
 import discord
 from dateparser.search import search_dates
 #Python
@@ -155,4 +156,10 @@ class Utility:
     def is_multi_server(cls, guild_id: int) -> bool:
         if not guild_id in cls.db.get_multi_server():
             return False
+        return True
+
+    @classmethod
+    def is_interaction_not_dm(cls, interaction: discord.Interaction) -> bool:
+        if isinstance(interaction.channel, discord.PartialMessageable):
+            return interaction.channel.type != private
         return True


### PR DESCRIPTION
This PR implements the majority of the commands as slash commands, including the main verify command. If the $verify command is sent as a DM, it will inform the user to use the slash command version of verify instead. All slash command replies are now ephemeral, which means that only the user who initiates the command will see the reply from the bot.

![image](https://user-images.githubusercontent.com/2121359/163894523-88947178-1775-44d8-846a-286f139c80ae.png)

![image](https://user-images.githubusercontent.com/2121359/163894636-294075f7-bb84-462a-bcdf-1acf1be9aa18.png)

![image](https://user-images.githubusercontent.com/2121359/163894993-7fc30465-1324-4256-9c21-09ea25d558f3.png)

Additionally, with the move to slash commands, it now allows users to autofill certain parameters (such as log channel and role selection) for commands which require it.

![image](https://user-images.githubusercontent.com/2121359/163894893-fb8b51a1-1128-4408-8a33-c033ad18b637.png)

The move to slash commands makes the bot much easier to use for both users wishing to verify their memberships, as well as moderators and administrators wanting to manage their server.