### PR TITLE
Fix missing server text for single-talent servers

### DIFF
--- a/app.py
+++ b/app.py
@@ -336,7 +336,7 @@ async def handle_denied(channel, msg, reaction, embed, target_member_id: int, us
         if Utility.is_multi_server(msg.guild.id):
             server = msg.guild.name
         else:
-            server = Utility.get_vtuber(msg.guild.id)
+            server = Utility.get_vtuber(msg.guild.id) + " server"
         await target_member.send("{}:\n{}".format(server, text_msg.content))
         await channel.send("Message was sent to {}.".format(target_member.mention), reference=text_msg, mention_author=False)
 


### PR DESCRIPTION
This partially reverts and corrects the issue in [this commit](https://github.com/nonJerry/VeraBot/commit/03492c80ca6ca8b235e191ce4e1595e0ed1eb663) as it should have been a string, not a reference to the server variable.
by @RisingFog 