### PR TITLE
Improve tracking for moderator verification actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -296,7 +296,7 @@ async def tree_error(interaction, error):
             logging.info("Could not message the user in command by %s", interaction.user.id)
             await interaction.response.send_message("Could not message the user.")
         elif isinstance(error, discord.errors.NotFound):
-            logging.info("Did not find interaction in %s by %s", interaction.guild_id, interaction.user.id)
+            logging.info("Did not find interaction in %s by %s", interaction.guild.id, interaction.user.id)
             await interaction.response.send_message("Had a problem finding the interaction, please try again", ephemeral=True)
     except discord.errors.NotFound:
         logging.info("Could not send the info of error")

--- a/membership.py
+++ b/membership.py
@@ -35,7 +35,7 @@ class Membership(commands.Cog):
         if vtuber or language:
             if vtuber:
                 server = Utility.map_vtuber_to_server(vtuber)
-            elif Utility.is_multi_server(interaction.guild_id):
+            elif Utility.is_multi_server(interaction.guild.id):
                 embed = Utility.create_supported_vtuber_embed()
                 await interaction.followup.send(content="Please use a valid supported VTuber!", embed=embed,
                                                 ephemeral=True)
@@ -51,11 +51,11 @@ class Membership(commands.Cog):
                 embed = Utility.create_supported_vtuber_embed()
                 await interaction.followup.send(content="Please use a valid supported VTuber!", embed=embed,
                                                 ephemeral=True)
-        elif Utility.is_multi_server(interaction.guild_id):
+        elif Utility.is_multi_server(interaction.guild.id):
             embed = Utility.create_supported_vtuber_embed()
             await interaction.followup.send(content="Please use a valid supported VTuber!", embed=embed, ephemeral=True)
         else:
-            await self.member_handler.add_to_queue(interaction, attachment, interaction.guild_id)
+            await self.member_handler.add_to_queue(interaction, attachment, interaction.guild.id)
 
     @verify.error
     async def verify_error(self, interaction, error):
@@ -68,8 +68,8 @@ class Membership(commands.Cog):
 
     @verify.autocomplete('vtuber')
     async def verify_autocomplete(self, interaction: discord.Interaction, current: str):
-        server_db = Database().get_server_db(interaction.guild_id)
-        if Utility.is_multi_server(interaction.guild_id):
+        server_db = Database().get_server_db(interaction.guild.id)
+        if Utility.is_multi_server(interaction.guild.id):
             multi_talents = server_db.get_multi_talents()
             vtubers = [m['idol'] for m in multi_talents]
             return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if
@@ -85,10 +85,10 @@ class Membership(commands.Cog):
     async def view_members(self, interaction: discord.Interaction, member: discord.User = None):
         await interaction.response.defer(ephemeral=True, thinking=True)
         if member:
-            logging.info(f"{interaction.user.id} used viewMember with ID in {interaction.guild_id}")
+            logging.info(f"{interaction.user.id} used viewMember with ID in {interaction.guild.id}")
             await self.member_handler.view_membership(interaction, member.id, None)
         else:
-            logging.info(f"{interaction.user.id} viewed all members in {interaction.guild_id}")
+            logging.info(f"{interaction.user.id} viewed all members in {interaction.guild.id}")
             await self.member_handler.view_membership(interaction, None)
 
     @app_commands.command(name="viewmembersfor",
@@ -98,15 +98,15 @@ class Membership(commands.Cog):
     async def view_members_multi(self, interaction: discord.Interaction, vtuber: str = None):
         await interaction.response.defer(ephemeral=True, thinking=True)
         if vtuber:
-            logging.info("%s viewed all members in %s for %s", interaction.user.id, interaction.guild_id, vtuber)
+            logging.info("%s viewed all members in %s for %s", interaction.user.id, interaction.guild.id, vtuber)
             await self.member_handler.view_membership(interaction, None, vtuber)
         else:
-            logging.info("%s viewed all members in %s", interaction.user.id, interaction.guild_id)
+            logging.info("%s viewed all members in %s", interaction.user.id, interaction.guild.id)
             await self.member_handler.view_membership(interaction, None, None)
 
     @view_members_multi.autocomplete('vtuber')
     async def view_members_multi_autocomplete(self, interaction: discord.Interaction, current: str):
-        server_db = Database().get_server_db(interaction.guild_id)
+        server_db = Database().get_server_db(interaction.guild.id)
         multi_talents = server_db.get_multi_talents()
         vtubers = [m['idol'] for m in multi_talents]
         return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if
@@ -120,12 +120,12 @@ class Membership(commands.Cog):
     async def set_membership(self, interaction: discord.Interaction, member: discord.User, date: str,
                              vtuber: str = None):
         await interaction.response.defer(ephemeral=True, thinking=True)
-        logging.info("%s used addMember in %s", interaction.user.id, interaction.guild_id)
+        logging.info("%s used addMember in %s", interaction.user.id, interaction.guild.id)
         await self.member_handler.set_membership(interaction, member.id, date, manual=True, vtuber=vtuber)
 
     @set_membership.autocomplete('vtuber')
     async def set_membership_autocomplete(self, interaction: discord.Interaction, current: str):
-        server_db = Database().get_server_db(interaction.guild_id)
+        server_db = Database().get_server_db(interaction.guild.id)
         multi_talents = server_db.get_multi_talents()
         vtubers = [m['idol'] for m in multi_talents]
         return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if
@@ -138,12 +138,12 @@ class Membership(commands.Cog):
     async def del_membership(self, interaction: discord.Interaction, member: discord.User, vtuber: str = None,
                              text: str = None):
         await interaction.response.defer(ephemeral=True, thinking=True)
-        logging.info("%s used delMember in %s", interaction.user.id, interaction.guild_id)
+        logging.info("%s used delMember in %s", interaction.user.id, interaction.guild.id)
         await self.member_handler.del_membership(interaction, member.id, text, manual=True, vtuber=vtuber)
 
     @del_membership.autocomplete('vtuber')
     async def del_membership_autocomplete(self, interaction: discord.Interaction, current: str):
-        server_db = Database().get_server_db(interaction.guild_id)
+        server_db = Database().get_server_db(interaction.guild.id)
         multi_talents = server_db.get_multi_talents()
         vtubers = [m['idol'] for m in multi_talents]
         return [app_commands.Choice(name=vtuber, value=vtuber) for vtuber in vtubers if
@@ -155,7 +155,7 @@ class Membership(commands.Cog):
     @app_commands.check(Utility.is_interaction_not_dm)
     async def purge_members(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True, thinking=True)
-        await self.member_handler.purge_memberships(interaction.guild_id)
+        await self.member_handler.purge_memberships(interaction.guild.id)
         await interaction.followup.send(
             "This was a hard check, it might have hit many members that still have a valid membership.", ephemeral=True)
 

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -148,13 +148,13 @@ class MembershipHandler:
 
     async def view_membership(self, interaction, member_id=None, vtuber=None):
         # if msg is empty, show all members
-        server_db = self.db.get_server_db(interaction.guild_id)
+        server_db = self.db.get_server_db(interaction.guild.id)
         if not member_id:
             count = 0
             embed_count = 0
             m = ""
             for member in server_db.get_members():
-                if Utility.is_multi_server(interaction.guild_id) and vtuber is not None and member.idol != vtuber:
+                if Utility.is_multi_server(interaction.guild.id) and vtuber is not None and member.idol != vtuber:
                     continue
                 count += 1
                 member_id = member.id
@@ -183,7 +183,7 @@ class MembershipHandler:
             return
 
         # Check if zoopass in database and delete
-        if Utility.is_multi_server(interaction.guild_id) and vtuber:
+        if Utility.is_multi_server(interaction.guild.id) and vtuber:
             target_membership = server_db.get_member_multi(member_id, vtuber)
         else:
             target_membership = server_db.get_member(member_id)
@@ -192,7 +192,7 @@ class MembershipHandler:
             return
 
         # Send information about membership
-        guild = self.bot.get_guild(interaction.guild_id)
+        guild = self.bot.get_guild(interaction.guild.id)
         target_member = guild.get_member(member_id)
 
         membership_date = target_membership.last_membership
@@ -422,7 +422,7 @@ class MembershipHandler:
         return (new_membership_date, membership_date_text, desc)
 
     async def set_membership(self, interaction, member_id, date, manual=True, actor=None, vtuber=None) -> bool:
-        guild_id = interaction.guild_id
+        guild_id = interaction.guild.id
         author_id = interaction.user.id
         dates = date.split("/")
 
@@ -484,7 +484,7 @@ class MembershipHandler:
         return True
 
     async def del_membership(self, interaction, member_id: int, text, dm_flag=True, manual=True, vtuber=None):
-        guild_id = interaction.guild_id
+        guild_id = interaction.guild.id
         author_id = interaction.user.id
         server_db = self.db.get_server_db(guild_id)
         result = 0

--- a/membership_handling.py
+++ b/membership_handling.py
@@ -485,7 +485,10 @@ class MembershipHandler:
 
     async def del_membership(self, interaction, member_id: int, text, dm_flag=True, manual=True, vtuber=None):
         guild_id = interaction.guild.id
-        author_id = interaction.user.id
+        if isinstance(interaction, discord.Message):
+            author_id = interaction.author.id
+        else:
+            author_id = interaction.user.id
         server_db = self.db.get_server_db(guild_id)
         result = 0
 

--- a/settings.py
+++ b/settings.py
@@ -24,10 +24,10 @@ class Settings(commands.Cog):
 
         title = "Current Settings"
         embed = discord.Embed(title = title, description = None)
-        server_db = self.db.get_server_db(interaction.guild_id)
+        server_db = self.db.get_server_db(interaction.guild.id)
 
         # VTuber
-        if Utility.is_multi_server(interaction.guild_id):
+        if Utility.is_multi_server(interaction.guild.id):
             multi_talents = server_db.get_multi_talents()
             idols = [m['idol'] for m in multi_talents]
             vtubers = ', '.join(idols).title()
@@ -77,7 +77,7 @@ class Settings(commands.Cog):
         embed.add_field(name='Proof Channel ID', value=str(proof_channel), inline=True)
         
         # is multi server
-        is_multi = Utility.is_multi_server(interaction.guild_id)
+        is_multi = Utility.is_multi_server(interaction.guild.id)
         embed.add_field(name='Multi Server', value=str(is_multi), inline=True)
 
         m = "These are your current settings.\nYour set expiration image is the picture.\n"
@@ -97,10 +97,10 @@ class Settings(commands.Cog):
             await interaction.followup.send("This Vtuber is already mapped to a server!")
             return
 
-        self.db.set_vtuber(vtuber_name, interaction.guild_id)
+        self.db.set_vtuber(vtuber_name, interaction.guild.id)
 
         await interaction.followup.send("Set VTuber name to " + vtuber_name, ephemeral=True)
-        logging.info("%s (%s) -> New Vtuber added: %s", interaction.guild.name, interaction.guild_id, vtuber_name)
+        logging.info("%s (%s) -> New Vtuber added: %s", interaction.guild.name, interaction.guild.id, vtuber_name)
 
     def check_vtuber(self, vtuber_name) -> bool:
         for element in self.db.get_vtuber_list():
@@ -118,12 +118,12 @@ class Settings(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         if self.check_role_integrity(interaction, role.id):
-            self.db.get_server_db(interaction.guild_id).set_member_role(role.id)
+            self.db.get_server_db(interaction.guild.id).set_member_role(role.id)
 
             await interaction.followup.send("Member role id set to " + str(role.id), ephemeral=True)
         else:
             await interaction.followup.send("ID does not refer to a legit role", ephemeral=True)
-        logging.info("%s set %s as member role.", interaction.guild_id, role.id)
+        logging.info("%s set %s as member role.", interaction.guild.id, role.id)
 
 
     @app_commands.command(name="logchannel", description="Sets the channel which is used to control the sent memberships.")
@@ -133,12 +133,12 @@ class Settings(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         if self.check_channel_integrity(channel.id):
-            self.db.get_server_db(interaction.guild_id).set_log_channel(channel.id)
-            logging.info("%s set %s as log channel.", interaction.guild_id, channel.id)
+            self.db.get_server_db(interaction.guild.id).set_log_channel(channel.id)
+            logging.info("%s set %s as log channel.", interaction.guild.id, channel.id)
             await interaction.followup.send("Log Channel id set to " + str(channel.id), ephemeral=True)
         else:
             await interaction.followup.send("ID does not refer to a legit channel", ephemeral=True)
-            logging.info("%s used a wrong ID as log channel.", interaction.guild_id)
+            logging.info("%s used a wrong ID as log channel.", interaction.guild.id)
 
 
 
@@ -149,11 +149,11 @@ class Settings(commands.Cog):
     async def set_picture(self, interaction: discord.Interaction, link: str):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
-        logging.info("{} set their picture: {}".format(str(interaction.guild_id), link))
+        logging.info("{} set their picture: {}".format(str(interaction.guild.id), link))
         from re import fullmatch
         match = fullmatch(r"http[s]?://[a-zA-Z0-9\_\-\.]+/[a-zA-Z0-9\_\-/]+\.(png|jpeg|jpg)", link)
         if match:
-            self.db.get_server_db(interaction.guild_id).set_picture(link)
+            self.db.get_server_db(interaction.guild.id).set_picture(link)
             await interaction.followup.send("Image for expiration message set.", ephemeral=True)
         else:
             await interaction.followup.send("Please send a legit link. Only jpg, jpeg and png are accepted.", ephemeral=True)
@@ -170,8 +170,8 @@ class Settings(commands.Cog):
             await interaction.followup.send(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
 
-        self.db.get_server_db(interaction.guild_id).set_automatic(flag)
-        logging.info("%s set auto to %s", interaction.guild_id, str(flag))
+        self.db.get_server_db(interaction.guild.id).set_automatic(flag)
+        logging.info("%s set auto to %s", interaction.guild.id, str(flag))
 
         await interaction.followup.send("Flag for automatic role handling set to " + str(flag), ephemeral=True)
 
@@ -187,8 +187,8 @@ class Settings(commands.Cog):
             await interaction.followup.send(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
 
-        self.db.get_server_db(interaction.guild_id).set_additional_proof(flag)
-        logging.info("%s set additional Proof to %s", interaction.guild_id, str(flag))
+        self.db.get_server_db(interaction.guild.id).set_additional_proof(flag)
+        logging.info("%s set additional Proof to %s", interaction.guild.id, str(flag))
 
         await interaction.followup.send("Flag for additional Proof set to " + str(flag), ephemeral=True)
 
@@ -206,8 +206,8 @@ class Settings(commands.Cog):
             await interaction.followup.send("This value cannot be more than 2 days.", ephemeral=True)
             return
         
-        self.db.get_server_db(interaction.guild_id).set_tolerance_duration(time)
-        logging.info("%s set Tolerance to %s", interaction.guild_id, time)
+        self.db.get_server_db(interaction.guild.id).set_tolerance_duration(time)
+        logging.info("%s set Tolerance to %s", interaction.guild.id, time)
 
         await interaction.followup.send("Time that users will still have access to the channel after their membership expired set to {} days.".format(str(time)), ephemeral=True)
 
@@ -226,8 +226,8 @@ class Settings(commands.Cog):
             await interaction.followup.send("This value cannot be more than 2 days.", ephemeral=True)
             return
 
-        self.db.get_server_db(interaction.guild_id).set_inform_duration(time)
-        logging.info("%s set prior Notice to %s", interaction.guild_id, time)
+        self.db.get_server_db(interaction.guild.id).set_inform_duration(time)
+        logging.info("%s set prior Notice to %s", interaction.guild.id, time)
 
         await interaction.followup.send("Users will be notified " + str(time) + " days before their membership ends.", ephemeral=True)
 
@@ -242,8 +242,8 @@ class Settings(commands.Cog):
             await interaction.followup.send(self.BOOLEAN_ONLY_TEXT, ephemeral=True)
             return
         
-        self.db.get_server_db(interaction.guild_id).set_logging(flag)
-        logging.info("%s set logging to %s", interaction.guild_id, str(flag))
+        self.db.get_server_db(interaction.guild.id).set_logging(flag)
+        logging.info("%s set logging to %s", interaction.guild.id, str(flag))
 
         await interaction.followup.send("Flag for logging set to " + str(flag), ephemeral=True)
 
@@ -265,8 +265,8 @@ class Settings(commands.Cog):
             await interaction.followup.send("You need to enable use_public_threads for VeraBot on your proof channel first!", ephemeral=True)
             return
 
-        self.db.get_server_db(interaction.guild_id).set_proof_channel(channel.id)
-        logging.info("%s set %s as proof channel.", interaction.guild_id, channel.id)
+        self.db.get_server_db(interaction.guild.id).set_proof_channel(channel.id)
+        logging.info("%s set %s as proof channel.", interaction.guild.id, channel.id)
 
         await interaction.followup.send("Proof Channel id set to " + str(channel.id), ephemeral=True)
 
@@ -278,9 +278,9 @@ class Settings(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         # multi-server cannot use threads
-        if Utility.is_multi_server(interaction.guild_id):
+        if Utility.is_multi_server(interaction.guild.id):
             await interaction.followup.send("You cannot enable threads as mutli-server!", ephemeral=True)
-            logging.info("%s tried to enable Threads as multi-server.", interaction.guild_id)
+            logging.info("%s tried to enable Threads as multi-server.", interaction.guild.id)
             return
 
         flag = Utility.text_to_boolean(flag)
@@ -289,7 +289,7 @@ class Settings(commands.Cog):
             return
 
         if flag:
-            channel = self.bot.get_channel(self.db.get_server_db(interaction.guild_id).get_proof_channel())
+            channel = self.bot.get_channel(self.db.get_server_db(interaction.guild.id).get_proof_channel())
             if not channel:
                 await interaction.followup.send("Please set a proof channel first!", ephemeral=True)
                 return
@@ -300,8 +300,8 @@ class Settings(commands.Cog):
                 await interaction.followup.send("You need to enable use_public_threads for VeraBot on your proof channel first!", ephemeral=True)
                 return
         # set value
-        self.db.get_server_db(interaction.guild_id).set_threads_enabled(flag)
-        logging.info("%s set threads to %s", interaction.guild_id, str(flag))
+        self.db.get_server_db(interaction.guild.id).set_threads_enabled(flag)
+        logging.info("%s set threads to %s", interaction.guild.id, str(flag))
 
         await interaction.followup.send("Flag for using threads set to " + str(flag), ephemeral=True)
 
@@ -323,17 +323,17 @@ class Settings(commands.Cog):
     async def enable_multi_server(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
-        if Utility.is_multi_server(interaction.guild_id):
-            logging.info("%s: Tried to enable the multi-talent function again.", interaction.guild_id)
+        if Utility.is_multi_server(interaction.guild.id):
+            logging.info("%s: Tried to enable the multi-talent function again.", interaction.guild.id)
             await interaction.followup.send("Your server already has enabled the usage of multiple talents!", ephemeral=True)
             return
-        if self.db.get_server_db(interaction.guild_id).get_threads_enabled():
+        if self.db.get_server_db(interaction.guild.id).get_threads_enabled():
             await interaction.followup.send("You cannot enable multi server with threads enabled!", ephemeral=True)
-            logging.info("%s: Tried to enable the multi-talent function with threads enabled.", interaction.guild_id)
+            logging.info("%s: Tried to enable the multi-talent function with threads enabled.", interaction.guild.id)
             return
 
-        self.db.add_multi_server(interaction.guild_id)
-        logging.info("%s: Enabled the multi-talent function.", interaction.guild_id)
+        self.db.add_multi_server(interaction.guild.id)
+        logging.info("%s: Enabled the multi-talent function.", interaction.guild.id)
 
         await interaction.followup.send("Management of several talents was activated for this server!", ephemeral=True)
 
@@ -343,13 +343,13 @@ class Settings(commands.Cog):
     async def disable_multi_server(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
-        if not Utility.is_multi_server(interaction.guild_id):
-            logging.info("%s: Tried to disabled the multi-talent function without having it enabled.", interaction.guild_id)
+        if not Utility.is_multi_server(interaction.guild.id):
+            logging.info("%s: Tried to disabled the multi-talent function without having it enabled.", interaction.guild.id)
             await interaction.followup.send("Your server has not enabled the usage of multiple talents!", ephemeral=True)
             return
         
-        self.db.remove_multi_server(interaction.guild_id)
-        logging.info("%s: Disabled the multi-talent function.", interaction.guild_id)
+        self.db.remove_multi_server(interaction.guild.id)
+        logging.info("%s: Disabled the multi-talent function.", interaction.guild.id)
 
         await interaction.followup.send("Management of several talents was disabled for this server! For this all added VTubers were removed. Please add the one wanted again using $setVtuber", ephemeral=True)
 
@@ -362,15 +362,15 @@ class Settings(commands.Cog):
     async def add_idol(self, interaction: discord.Interaction, name: str, log: discord.TextChannel, role: discord.Role):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
-        if not Utility.is_multi_server(interaction.guild_id):
-            logging.info("%s: Tried to use mutli-talent ADD without having it enabled.", interaction.guild_id)
+        if not Utility.is_multi_server(interaction.guild.id):
+            logging.info("%s: Tried to use mutli-talent ADD without having it enabled.", interaction.guild.id)
             await interaction.followup.send("Your server has not enabled the usage of multiple talents. If you intend to use this feature, please use `$enableMultiServer` first. Otherwise `$setVtuber` is the command you wanted to use.", ephemeral=True)
             return
-        logging.info("Multi-Server %s: Trying to add %s as talent.", interaction.guild_id, name)
+        logging.info("Multi-Server %s: Trying to add %s as talent.", interaction.guild.id, name)
 
         # Check for integrity
         if self.check_vtuber(name):       
-            logging.info("%s: Talent %s already exists.", interaction.guild_id, name)   
+            logging.info("%s: Talent %s already exists.", interaction.guild.id, name)   
             await interaction.followup.send("This Vtuber is already mapped to a server!", ephemeral=True)
             return
 
@@ -382,9 +382,9 @@ class Settings(commands.Cog):
             return
 
         # Finally add to db
-        self.db.get_server_db(interaction.guild_id).add_multi_talent(name, log.id, role.id)
-        self.db.set_vtuber(name, interaction.guild_id)
-        logging.info("%s: Added %s with %s as Log Channel and %s as Role.", interaction.guild_id, name, log.id, role.id)
+        self.db.get_server_db(interaction.guild.id).add_multi_talent(name, log.id, role.id)
+        self.db.set_vtuber(name, interaction.guild.id)
+        logging.info("%s: Added %s with %s as Log Channel and %s as Role.", interaction.guild.id, name, log.id, role.id)
 
         await interaction.followup.send("Successfully added the new talent!", ephemeral=True)
 
@@ -395,12 +395,12 @@ class Settings(commands.Cog):
     async def remove_idol(self, interaction: discord.Interaction, name: str):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
-        if not Utility.is_multi_server(interaction.guild_id):
-            logging.info("%s: Tried to remove a mutli-talent without having it enabled.", interaction.guild_id)
+        if not Utility.is_multi_server(interaction.guild.id):
+            logging.info("%s: Tried to remove a mutli-talent without having it enabled.", interaction.guild.id)
             await interaction.followup.send("Your server has not enabled the usage of multiple talents.", ephemeral=True)
             return
-        if self.db.get_server_db(interaction.guild_id).remove_multi_talent(name):
-            self.db.remove_multi_talent_vtuber(interaction.guild_id, name)
+        if self.db.get_server_db(interaction.guild.id).remove_multi_talent(name):
+            self.db.remove_multi_talent_vtuber(interaction.guild.id, name)
             logging.info("Removed %s from VTuber list", name)
             await interaction.followup.send("Successfully removed {}!".format(name), ephemeral=True)
         else:

--- a/views.py
+++ b/views.py
@@ -118,7 +118,7 @@ class PersistentView(discord.ui.View):
             else:
                 server = Utility.get_vtuber(msg.guild.id) + " server"
             await target_member.send("{}:\n{}".format(server, modal.message))
-            await interaction.followup.send("Message was sent by `{}` to {}:\n```{}```".format(interaction.user.mention, target_member.mention, modal.message))
+            await interaction.followup.send("Message was sent by {} to {}:\n```{}```".format(interaction.user.mention, target_member.mention, modal.message))
 
             if Utility.is_multi_server(interaction.guild.id):
                 vtuber = embed.fields[1].value

--- a/views.py
+++ b/views.py
@@ -43,6 +43,12 @@ class PersistentView(discord.ui.View):
 
         if server_db.get_automatic():
             await interaction.message.add_reaction('👌')
+            # track who verifies even if roles are automatically assigned
+            target_member = interaction.guild.get_member(target_member_id)
+            embed = interaction.message.embeds[0]
+            embed.description = "**VERIFIED:** {}\nUser: {}\nBy: {}".format(embed.fields[0].value, target_member.mention, 
+                                                                            interaction.user.mention)
+            await interaction.edit_original_response(embed=embed)
             self.stop()
         else:
             membership_date = embed.fields[0].value

--- a/views.py
+++ b/views.py
@@ -112,7 +112,7 @@ class PersistentView(discord.ui.View):
             else:
                 server = Utility.get_vtuber(msg.guild.id) + " server"
             await target_member.send("{}:\n{}".format(server, modal.message))
-            await interaction.followup.send("Message was sent to {}: {}".format(target_member.mention, modal.message))
+            await interaction.followup.send("Message was sent by `{}` to {}: {}".format(interaction.user.mention, target_member.mention, modal.message))
 
             if Utility.is_multi_server(interaction.guild.id):
                 vtuber = embed.fields[1].value

--- a/views.py
+++ b/views.py
@@ -112,7 +112,7 @@ class PersistentView(discord.ui.View):
             else:
                 server = Utility.get_vtuber(msg.guild.id) + " server"
             await target_member.send("{}:\n{}".format(server, modal.message))
-            await interaction.followup.send("Message was sent by `{}` to {}:\n{}".format(interaction.user.mention, target_member.mention, modal.message))
+            await interaction.followup.send("Message was sent by `{}` to {}:\n```{}```".format(interaction.user.mention, target_member.mention, modal.message))
 
             if Utility.is_multi_server(interaction.guild.id):
                 vtuber = embed.fields[1].value

--- a/views.py
+++ b/views.py
@@ -112,7 +112,7 @@ class PersistentView(discord.ui.View):
             else:
                 server = Utility.get_vtuber(msg.guild.id) + " server"
             await target_member.send("{}:\n{}".format(server, modal.message))
-            await interaction.followup.send("Message was sent by `{}` to {}: {}".format(interaction.user.mention, target_member.mention, modal.message))
+            await interaction.followup.send("Message was sent by `{}` to {}:\n{}".format(interaction.user.mention, target_member.mention, modal.message))
 
             if Utility.is_multi_server(interaction.guild.id):
                 vtuber = embed.fields[1].value

--- a/views.py
+++ b/views.py
@@ -112,7 +112,7 @@ class PersistentView(discord.ui.View):
             else:
                 server = Utility.get_vtuber(msg.guild.id) + " server"
             await target_member.send("{}:\n{}".format(server, modal.message))
-            await interaction.followup.send("Message was sent to {}.".format(target_member.mention))
+            await interaction.followup.send("Message was sent to {}: {}".format(target_member.mention, modal.message))
 
             if Utility.is_multi_server(interaction.guild.id):
                 vtuber = embed.fields[1].value


### PR DESCRIPTION
This will log what message was actually sent to the user as part of the rejection process, as well as track who verifies a user's membership in servers with automatic role giving enabled. This should be helpful to server admins trying to keep track of VeraBot actions.